### PR TITLE
Do not assign values to STDERR, as it is a read-only file.

### DIFF
--- a/src/kew.c
+++ b/src/kew.c
@@ -692,9 +692,9 @@ void cleanupOnExit()
         showCursor();
 
 #ifdef DEBUG
-    fclose(logFile);
-    freopen("/dev/stderr", "w", stderr);
+        fclose(logFile);    
 #endif
+        freopen("/dev/stderr", "w", stderr);
 }
 
 void run()


### PR DESCRIPTION
The stderr stream is a constant and cannot be directly assigned a new value. It is intended for writing error messages and diagnostic information to the standard error output device. That's why it wasn't compiling, I'm not familiar with Glib, it might not complain about this, but Musl does, even when in -pendatic mode.