### PR TITLE
build: let pkg-config handle the CFLAGS and LIBS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 CC = gcc
 PKG_CONFIG	?= pkg-config
-CFLAGS = -I/usr/include/vorbis -I/usr/include/opus -I/usr/include/stb -Iinclude/imgtotxt/ext -Iinclude/imgtotxt -I/usr/include/ffmpeg -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/libavformat -Iinclude/miniaudio -O2 -g $(shell $(PKG_CONFIG) --cflags gio-2.0 chafa libavformat fftw3f)
+CFLAGS = -I/usr/include/stb -Iinclude/imgtotxt/ext -Iinclude/imgtotxt -I/usr/include/ffmpeg -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/libavformat -Iinclude/miniaudio -O2 -g $(shell $(PKG_CONFIG) --cflags gio-2.0 chafa libavformat fftw3f opus opusfile vorbis)
 CFLAGS += -fstack-protector-strong -Wformat -Werror=format-security -fPIE -fstack-protector -fstack-protector-strong -D_FORTIFY_SOURCE=2
 CFLAGS += -Wall -Wpointer-arith
-LIBS = -latomic -lpthread -lrt -pthread -lm -lfreeimage -lglib-2.0  -lopus -lopusfile -lvorbisfile $(shell $(PKG_CONFIG) --libs gio-2.0 chafa libavformat fftw3f)
+LIBS = -latomic -lpthread -lrt -pthread -lm -lfreeimage -lglib-2.0  $(shell $(PKG_CONFIG) --libs gio-2.0 chafa libavformat fftw3f opus opusfile vorbis)
 LDFLAGS = -pie -Wl,-z,relro
 
 OBJDIR = src/obj
@@ -11,7 +11,7 @@ PREFIX = /usr
 SRCS = src/soundcommon.c src/player.c src/soundopus.c src/soundvorbis.c src/soundbuiltin.c src/soundpcm.c src/mpris.c src/playerops.c src/volume.c src/cutils.c src/soundgapless.c src/songloader.c src/file.c src/chafafunc.c src/cache.c src/metadata.c src/playlist.c src/stringfunc.c src/term.c  src/settings.c src/albumart.c src/visuals.c src/kew.c
 OBJS = $(SRCS:src/%.c=$(OBJDIR)/%.o)
 
-MAN_PAGE = kew.1 
+MAN_PAGE = kew.1
 MAN_DIR ?= $(PREFIX)/share/man
 
 all: kew


### PR DESCRIPTION
Have some issue of configuring the CFLAGS and LIBS for upgrading homebrew formula, modifying the Makefile to have pkg-config handle the build dependencies.

relates to https://github.com/Homebrew/homebrew-core/pull/154990