### PR TITLE
adding libnotify to the project, updating code and README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 CC = gcc
 PKG_CONFIG	?= pkg-config
-CFLAGS = -I/usr/include -I/usr/include/ogg -I/usr/include/opus -I/usr/include/stb -Iinclude/imgtotxt/ext -Iinclude/imgtotxt -I/usr/include/ffmpeg -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -Iinclude/miniaudio -O1 $(shell $(PKG_CONFIG) --cflags libavcodec libavutil libavformat libswresample gio-2.0 chafa fftw3f opus opusfile vorbis)
+CFLAGS = -I/usr/include -I/usr/include/ogg -I/usr/include/opus -I/usr/include/stb -Iinclude/imgtotxt/ext -Iinclude/imgtotxt -I/usr/include/ffmpeg -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -Iinclude/miniaudio -I/usr/include/gdk-pixbuf-2.0 -O1 $(shell $(PKG_CONFIG) --cflags libavcodec libavutil libavformat libswresample gio-2.0 chafa fftw3f opus opusfile vorbis)
 CFLAGS += -fstack-protector-strong -Wformat -Werror=format-security -fPIE -fstack-protector -fstack-protector-strong -D_FORTIFY_SOURCE=2
 CFLAGS += -Wall -Wextra -Wpointer-arith
-LIBS = -L/usr/lib -lfreeimage -lpthread -lrt -pthread -lm -lglib-2.0  $(shell $(PKG_CONFIG) --libs libavcodec libavutil libavformat libswresample gio-2.0 chafa fftw3f opus opusfile vorbis vorbisfile)
+LIBS = -L/usr/lib -lfreeimage -lpthread -lrt -lnotify -pthread -lm -lglib-2.0  $(shell $(PKG_CONFIG) --libs libavcodec libavutil libavformat libswresample gio-2.0 chafa fftw3f opus opusfile vorbis vorbisfile)
 LDFLAGS = -pie -Wl,-z,relro
 
 ifeq ($(CC),gcc)

--- a/README.md
+++ b/README.md
@@ -79,16 +79,17 @@ kew dependencies are:
 * libvorbis
 * pkg-config
 * glib2.0 and AVFormat. These should be installed with the others, if not install them.
+* libnotify
 
 Install FFmpeg, FFTW, Chafa and FreeImage using your distro's package manager. For instance:
 
 ```bash
-apt install ffmpeg libfftw3-dev libopus-dev libopusfile-dev libvorbis-dev git gcc make libchafa-dev libfreeimage-dev libavformat-dev libglib2.0-dev
+apt install ffmpeg libfftw3-dev libopus-dev libopusfile-dev libvorbis-dev git gcc make libchafa-dev libfreeimage-dev libavformat-dev libglib2.0-dev libnotify-dev
 ```
 Or:
 
 ```bash
-pacman -Syu ffmpeg fftw git gcc make chafa freeimage glib2 opus opusfile libvorbis
+pacman -Syu ffmpeg fftw git gcc make chafa freeimage glib2 opus opusfile libvorbis libnotify
 ```
 
 Then run this (either git clone or unzip a release zip into a folder of your choice):

--- a/install.sh
+++ b/install.sh
@@ -15,11 +15,11 @@ fi
 # Install dependencies based on the package manager available
 echo "Installing missing dependencies"
 if command -v apt &>/dev/null; then
-    apt install -y pkg-config ffmpeg libfftw3-dev libopus-dev libopusfile-dev libvorbis-dev git gcc make libchafa-dev libfreeimage-dev libavformat-dev libglib2.0-dev
+    apt install -y pkg-config ffmpeg libfftw3-dev libopus-dev libopusfile-dev libvorbis-dev git gcc make libchafa-dev libfreeimage-dev libavformat-dev libglib2.0-dev libnotify-dev
 elif command -v yum &>/dev/null; then
     yum install -y pkgconfig ffmpeg fftw-devel opus-devel opusfile-devel libvorbis-devel git gcc make chafa-devel libfreeimage-devel libavformat-devel glib2-devel
 elif command -v pacman &>/dev/null; then
-    pacman -Syu --noconfirm --needed pkg-config ffmpeg fftw git gcc make chafa freeimage glib2 opus opusfile libvorbis
+    pacman -Syu --noconfirm --needed pkg-config ffmpeg fftw git gcc make chafa freeimage glib2 opus opusfile libvorbis libnotify
 elif command -v dnf &>/dev/null; then
     dnf install -y pkg-config ffmpeg-free-devel fftw-devel opus-devel opusfile-devel libvorbis-devel git gcc make chafa-devel freeimage-devel libavformat-free-devel glib2-devel
 elif command -v zypper &>/dev/null; then

--- a/src/kew.c
+++ b/src/kew.c
@@ -60,6 +60,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
 #include "soundcommon.h"
 #include "songloader.h"
 #include "utils.h"
+#include "libnotify/notify.h"
 
 // #define DEBUG 1
 #define MAX_TMP_SEQ_LEN 256 // Maximum length of temporary sequence buffer
@@ -1012,6 +1013,7 @@ void init()
         createLibrary(&settings);
         setlocale(LC_ALL, "");
         fflush(stdout);
+        notify_init("kew");
 
 #ifdef DEBUG
         g_setenv("G_MESSAGES_DEBUG", "all", TRUE);

--- a/src/soundcommon.h
+++ b/src/soundcommon.h
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include "file.h"
 #include "utils.h"
+#include "libnotify/notify.h"
 
 #ifndef MAXPATHLEN
 #define MAXPATHLEN 4096


### PR DESCRIPTION
See #142 

Replaced `execv` with a more proper usage of the library. On the downside, this library now needs to be added to the project.

Main reason for this is that notifications flood (my) notification bar, so this ensures that only one notification is used and updated.

The layout also slightly changed, since the library doesn't seem to allow `NULL` or "" to be set as the summary (from what i tested), so I split it into artist and track name.

Previous:
![image](https://github.com/ravachol/kew/assets/59805622/bbb867a0-0a2a-4d68-86b1-2aca4efed220)

Now:
![image](https://github.com/ravachol/kew/assets/59805622/0d5ee9a6-8580-4aa1-b298-b8edbf530c24)

I am unaware of how this works on different setups (mine is arch + wayland), so perhaps this is not as visually appealing as it is for me.

There is a an alternative way of making this work by using `excev`, since the `notify-send` can return the replacment-id of the notification, which can then be used to update it. This would be a bit more of a barbaric solution.