### PR TITLE
alternate screen buffer

### DIFF
--- a/src/kew.c
+++ b/src/kew.c
@@ -1062,8 +1062,8 @@ void cleanupOnExit()
 #ifdef USE_DBUS
         cleanupDbusConnection();
 #endif
-        resetConsole();
         showCursor();
+        exitAlternateScreenBuffer();
         fflush(stdout);
 
         if (noMusicFound)
@@ -1501,6 +1501,7 @@ int main(int argc, char *argv[])
                 exit(0);
         }
 
+        enterAlternateScreenBuffer();
         initState(&appState);
         getConfig(&settings, ui);
         mapSettingsToKeys(&settings, keyMappings);

--- a/src/term.c
+++ b/src/term.c
@@ -219,3 +219,13 @@ int getIndentation(int terminalWidth)
         int indent = ((term_w - terminalWidth) / 2) + 1;
         return (indent > 0) ? indent : 0;
 }
+
+void enterAlternateScreenBuffer() {
+        // Enter alternate screen buffer
+        printf("\033[?1049h");
+}
+
+void exitAlternateScreenBuffer() {
+        // Exit alternate screen buffer
+        printf("\033[?1049l");
+}

--- a/src/term.h
+++ b/src/term.h
@@ -66,4 +66,8 @@ void clearScreen(void);
 
 int readInputSequence(char *seq, size_t seqSize);
 
+void enterAlternateScreenBuffer(void);
+
+void exitAlternateScreenBuffer(void);
+
 #endif


### PR DESCRIPTION
Modern terminal emulators support an "alternate screen buffer", which temporarily replaces the default screen buffer. When the program exits, the alternate buffer is discarded, and the default screen (with previous commands and outputs) is restored.f