### PR TITLE
Add cross-platform process check for macOS

### DIFF
--- a/src/kew.c
+++ b/src/kew.c
@@ -1294,12 +1294,27 @@ void handleOptions(int *argc, char *argv[], UISettings *ui)
                 removeArgElement(argv, idx, argc);
 }
 
-int isProcessRunning(pid_t pid)
-{
-        char proc_path[64];
-        snprintf(proc_path, sizeof(proc_path), "/proc/%d", pid);
-        struct stat statbuf;
-        return (stat(proc_path, &statbuf) == 0);
+/*
+ * Checks if a process with the given PID is running
+ *
+ * Returns:
+ *  1 if the process is running, 0 otherwise.
+ */
+int isProcessRunning(pid_t pid) {
+    if (pid <= 0) {
+        return 0; // Invalid PID
+    }
+
+#if defined(__APPLE__)
+    char cmd[64];
+    snprintf(cmd, sizeof(cmd), "ps -p %d > /dev/null 2>&1", pid);
+    return (system(cmd) == 0);
+#else
+    char proc_path[64];
+    snprintf(proc_path, sizeof(proc_path), "/proc/%d", pid);
+    struct stat statbuf;
+    return (stat(proc_path, &statbuf) == 0);
+#endif
 }
 
 // Ensures only a single instance of kew can run at a time for the current user.


### PR DESCRIPTION
Use the `ps` command since macOS does not have a `/proc` filesystem.