### PR TITLE
refactor: remove the global variable `duration`

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -402,8 +402,10 @@ void printTime(double elapsedSeconds, AppState *state)
         int term_w, term_h;
         getTermSize(&term_w, &term_h);
         printBlankSpaces(indent);
-        if (term_h > minHeight)
+        if (term_h > minHeight) {
+                double duration = getCurrentSongData()->duration;
                 printProgress(elapsedSeconds, duration);
+        }
 }
 
 int calcIndentNormal(void)

--- a/src/player.c
+++ b/src/player.c
@@ -1392,8 +1392,6 @@ int printPlayer(SongData *songdata, double elapsedSeconds, AppSettings *settings
 
                 if (songdata != NULL && songdata->metadata != NULL && !songdata->hasErrors && (songdata->hasErrors < 1))
                 {
-                        duration = songdata->duration;
-
                         ui->color.r = songdata->red;
                         ui->color.g = songdata->green;
                         ui->color.b = songdata->blue;

--- a/src/player.c
+++ b/src/player.c
@@ -1,4 +1,5 @@
 #include "player.h"
+#include "playerops.h"
 /*
 
 player.c
@@ -950,6 +951,7 @@ void printVisualizer(double elapsedSeconds, AppState *state)
                 visualizerWidth = (visualizerWidth > term_w - 2) ? term_w - 2 : visualizerWidth;
                 visualizerWidth -= 1;
                 uis->numProgressBars = (int)visualizerWidth / 2;
+                double duration = getCurrentSongData()->duration;
 
 #ifndef __APPLE__
                 saveCursorPosition();

--- a/src/playerops.c
+++ b/src/playerops.c
@@ -622,6 +622,7 @@ void seekBack(UIState *uis)
         if (isPaused())
                 return;
 
+        double duration = currentSong->song.duration;
         if (duration != 0.0)
         {
                 float step = 100 / uis->numProgressBars;

--- a/src/playerops.c
+++ b/src/playerops.c
@@ -464,6 +464,7 @@ void calcElapsedTime(void)
                                  (double)(current_time.tv_nsec - start_time.tv_nsec) / 1e9;
                 double seekElapsed = getSeekElapsed();
                 double diff = elapsedSeconds + (seekElapsed + seekAccumulatedSeconds - totalPauseSeconds);
+                double duration = getCurrentSongData()->duration;
 
                 if (diff < 0)
                         seekElapsed -= diff;

--- a/src/playerops.c
+++ b/src/playerops.c
@@ -516,6 +516,7 @@ void flushSeek(void)
                 setSeekElapsed(getSeekElapsed() + seekAccumulatedSeconds);
                 seekAccumulatedSeconds = 0.0;
                 calcElapsedTime();
+                double duration = getCurrentSongData()->duration;
                 float percentage = elapsedSeconds / (float)duration * 100.0;
 
                 if (percentage < 0.0)

--- a/src/playerops.c
+++ b/src/playerops.c
@@ -536,6 +536,7 @@ bool setPosition(gint64 newPosition)
                 return false;
 
         gint64 currentPositionMicroseconds = llround(elapsedSeconds * G_USEC_PER_SEC);
+        double duration = getCurrentSongData()->duration;
 
         if (duration != 0.0)
         {

--- a/src/playerops.c
+++ b/src/playerops.c
@@ -556,6 +556,7 @@ bool seekPosition(gint64 offset)
         if (isPaused())
                 return false;
 
+        double duration = getCurrentSongData()->duration;
         if (duration != 0.0)
         {
                 gint64 step = offset;

--- a/src/playerops.c
+++ b/src/playerops.c
@@ -591,6 +591,7 @@ void seekForward(UIState *uis)
         if (isPaused())
                 return;
 
+        double duration = currentSong->song.duration;
         if (duration != 0.0)
         {
                 float step = 100 / uis->numProgressBars;

--- a/src/soundcommon.c
+++ b/src/soundcommon.c
@@ -1,4 +1,5 @@
 #include "soundcommon.h"
+#include "playerops.h"
 
 /*
 
@@ -948,6 +949,7 @@ double getSeekElapsed(void)
 
 double getPercentageElapsed(void)
 {
+        double duration = getCurrentSongData()->duration;
         return elapsedSeconds / duration;
 }
 

--- a/src/soundcommon.c
+++ b/src/soundcommon.c
@@ -41,7 +41,6 @@ enum AudioImplementation currentImplementation = NONE;
 
 AppState appState;
 volatile bool refresh = true; // Should the whole view be refreshed next time it redraws
-double duration;
 
 double elapsedSeconds = 0.0;
 

--- a/src/soundcommon.h
+++ b/src/soundcommon.h
@@ -114,8 +114,6 @@ extern AppState appState;
 
 extern AudioData audioData;
 
-extern double duration;
-
 extern double elapsedSeconds;
 
 extern bool hasSilentlySwitched;


### PR DESCRIPTION
Remove the global variable `duration`. Use `getCurrentSongData()->duration` or `currentSong->song.duration` instead.