### PR TITLE
Add option in configuration file to change title delay in track view

### DIFF
--- a/src/appstate.h
+++ b/src/appstate.h
@@ -44,6 +44,7 @@ typedef struct
         bool hideHelp;                                  // No help text at top
         bool allowNotifications;                        // Send desktop notifications or not
         int visualizerHeight;                           // Height in characters of the spectrum visualizer
+        int titleDelay;                                 // Delay when drawing title in track view
         int cacheLibrary;                               // Cache the library or not
         bool quitAfterStopping;                         // Exit kew when the music stops or not
         time_t lastTimeAppRan;                          // When did this app run last, used for updating the cached library if it has been modified since that time
@@ -95,6 +96,7 @@ typedef struct
         char useConfigColors[2];
         char visualizerEnabled[2];
         char visualizerHeight[6];
+        char titleDelay[6];
         char togglePlaylist[6];
         char toggleBindings[6];
         char volumeUp[6];

--- a/src/kew.c
+++ b/src/kew.c
@@ -1518,6 +1518,7 @@ void initState(AppState *state)
         state->uiSettings.coverAnsi = false;
         state->uiSettings.uiEnabled = true;
         state->uiSettings.visualizerHeight = 5;
+        state->uiSettings.titleDelay = 9;
         state->uiSettings.cacheLibrary = -1;
         state->uiSettings.useConfigColors = false;
         state->uiSettings.color.r = 125;

--- a/src/player.c
+++ b/src/player.c
@@ -257,9 +257,12 @@ void printTitleWithDelay(const char *text, int delay, int maxWidth)
                 }
                 printf("█");
                 fflush(stdout);
-                c_sleep(delay);
+
+                if (delay)
+                        c_sleep(delay);
         }
-        c_sleep(delay * 20);
+        if (delay)
+                c_sleep(delay * 20);
         printf("\r");
         printf("\033[K");
         printBlankSpaces(indent);
@@ -328,7 +331,7 @@ void printBasicMetadata(TagSettings const *metadata, UISettings *ui)
                         printf("\033[1;38;2;%03u;%03u;%03um", pixel.r, pixel.g, pixel.b);
                 }
 
-                printTitleWithDelay(metadata->title, 9, maxWidth - 2);
+                printTitleWithDelay(metadata->title, ui->titleDelay, maxWidth - 2);
         }
         else
         {
@@ -386,7 +389,9 @@ void printMetadata(TagSettings const *metadata, UISettings *ui)
 {
         if (appState.currentView == LIBRARY_VIEW || appState.currentView == PLAYLIST_VIEW || appState.currentView == SEARCH_VIEW)
                 return;
-        c_sleep(100);
+
+        if (ui->titleDelay)
+                c_sleep(100);
 
         if (ui->useConfigColors)
                 setDefaultTextColor();

--- a/src/settings.c
+++ b/src/settings.c
@@ -46,6 +46,7 @@ AppSettings constructAppSettings(KeyValuePair *pairs, int count)
         c_strcpy(settings.hideLogo, "0", sizeof(settings.hideLogo));
         c_strcpy(settings.hideHelp, "0", sizeof(settings.hideHelp));
         c_strcpy(settings.cacheLibrary, "-1", sizeof(settings.cacheLibrary));
+        c_strcpy(settings.titleDelay, "9", sizeof(settings.titleDelay));
 
         c_strcpy(settings.tabNext, "\t", sizeof(settings.tabNext));
         c_strcpy(settings.volumeUp, "+", sizeof(settings.volumeUp));
@@ -134,6 +135,10 @@ AppSettings constructAppSettings(KeyValuePair *pairs, int count)
                 else if (strcmp(lowercaseKey, "visualizerheight") == 0)
                 {
                         snprintf(settings.visualizerHeight, sizeof(settings.visualizerHeight), "%s", pair->value);
+                }
+                else if (strcmp(lowercaseKey, "titledelay") == 0)
+                {
+                        snprintf(settings.titleDelay, sizeof(settings.titleDelay), "%s", pair->value);
                 }
                 else if (strcmp(lowercaseKey, "volumeup") == 0)
                 {
@@ -496,13 +501,17 @@ void getConfig(AppSettings *settings, UISettings *ui)
         if (temp2 > 0)
                 ui->visualizerHeight = temp2;
 
-        int temp3 = getNumber(settings->lastVolume);
+        int temp3 = getNumber(settings->titleDelay);
         if (temp3 >= 0)
-                setVolume(temp3);
+                ui->titleDelay = temp3;
 
-        int temp4 = getNumber(settings->cacheLibrary);
+        int temp4 = getNumber(settings->lastVolume);
         if (temp4 >= 0)
-                ui->cacheLibrary = temp4;
+                setVolume(temp4);
+
+        int temp5 = getNumber(settings->cacheLibrary);
+        if (temp5 >= 0)
+                ui->cacheLibrary = temp5;
 
         getMusicLibraryPath(settings->path);
         free(configdir);
@@ -538,6 +547,10 @@ void setConfig(AppSettings *settings, UISettings *ui)
         {
                 snprintf(settings->visualizerHeight, sizeof(settings->visualizerHeight), "%d", ui->visualizerHeight);
         }
+        if (settings->titleDelay[0] == '\0')
+        {
+                snprintf(settings->titleDelay, sizeof(settings->titleDelay), "%d", ui->titleDelay);
+        }
         if (settings->hideLogo[0] == '\0')
                 ui->hideLogo ? c_strcpy(settings->hideLogo, "1", sizeof(settings->hideLogo)) : c_strcpy(settings->hideLogo, "0", sizeof(settings->hideLogo));
         if (settings->hideHelp[0] == '\0')
@@ -556,6 +569,7 @@ void setConfig(AppSettings *settings, UISettings *ui)
         settings->coverAnsi[1] = '\0';
         settings->visualizerEnabled[1] = '\0';
         settings->visualizerHeight[5] = '\0';
+        settings->titleDelay[5] = '\0';
         settings->lastVolume[5] = '\0';
         settings->useConfigColors[1] = '\0';
         settings->allowNotifications[1] = '\0';
@@ -571,6 +585,8 @@ void setConfig(AppSettings *settings, UISettings *ui)
         fprintf(file, "coverAnsi=%s\n", settings->coverAnsi);
         fprintf(file, "visualizerEnabled=%s\n", settings->visualizerEnabled);
         fprintf(file, "visualizerHeight=%s\n", settings->visualizerHeight);
+        fprintf(file, "# Delay when drawing title in track view, set to 0 to have no delay\n");
+        fprintf(file, "titleDelay=%s\n", settings->titleDelay);
         fprintf(file, "useConfigColors=%s\n", settings->useConfigColors);
         fprintf(file, "allowNotifications=%s\n", settings->allowNotifications);
         fprintf(file, "hideLogo=%s\n", settings->hideLogo);


### PR DESCRIPTION
Whenever I switch to the track view, I didn't like the way that there was a delay for drawing the text.
Previously, the a hard coded value of `9` was passed to the `printTitleWithDelay` function in `player.c`,
This PR allows the delay of 9 to be changed in the configuration file, like this:

```
titleDelay=0
```

Setting the value to 0 will make the program instantly switch to the track view, which is what I personally prefer.
9 is the default in the configuration file, as it was the value passed to the function originally.