### PR TITLE
Clean up writing titleDelay to config file

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -604,7 +604,7 @@ void setConfig(AppSettings *settings, UISettings *ui)
         fprintf(file, "\n# Cache: Set to 1 to use cache of the music library directory tree for faster startup times.\n");
         fprintf(file, "cacheLibrary=%s\n", settings->cacheLibrary);
 
-        fprintf(file, "# Delay when drawing title in track view, set to 0 to have no delay.\n");
+        fprintf(file, "\n# Delay when drawing title in track view, set to 0 to have no delay.\n");
         fprintf(file, "titleDelay=%s\n", settings->titleDelay);
 
         fprintf(file, "\n# Same as '--quitonstop' flag, exits after playing the whole playlist.\n");

--- a/src/settings.c
+++ b/src/settings.c
@@ -595,8 +595,6 @@ void setConfig(AppSettings *settings, UISettings *ui)
         fprintf(file, "coverAnsi=%s\n", settings->coverAnsi);
         fprintf(file, "visualizerEnabled=%s\n", settings->visualizerEnabled);
         fprintf(file, "visualizerHeight=%s\n", settings->visualizerHeight);
-        fprintf(file, "# Delay when drawing title in track view, set to 0 to have no delay.\n");
-        fprintf(file, "titleDelay=%s\n", settings->titleDelay);
         fprintf(file, "useConfigColors=%s\n", settings->useConfigColors);
         fprintf(file, "allowNotifications=%s\n", settings->allowNotifications);
         fprintf(file, "hideLogo=%s\n", settings->hideLogo);
@@ -605,6 +603,9 @@ void setConfig(AppSettings *settings, UISettings *ui)
 
         fprintf(file, "\n# Cache: Set to 1 to use cache of the music library directory tree for faster startup times.\n");
         fprintf(file, "cacheLibrary=%s\n", settings->cacheLibrary);
+
+        fprintf(file, "# Delay when drawing title in track view, set to 0 to have no delay.\n");
+        fprintf(file, "titleDelay=%s\n", settings->titleDelay);
 
         fprintf(file, "\n# Same as '--quitonstop' flag, exits after playing the whole playlist.\n");
         fprintf(file, "quitOnStop=%s\n", settings->quitAfterStopping);


### PR DESCRIPTION
Now, the titleDelay option in the config file is no longer sandwiched awkwardly between the other options, and is spaced out, along with the rest of the options with comments pertaining to them (for example, the cacheLibrary and quitOnStop options).