### PR TITLE
Add back mouse support and replace left click with middle click

### DIFF
--- a/src/appstate.h
+++ b/src/appstate.h
@@ -150,7 +150,7 @@ typedef struct
         char hardRemove2[6];
         char mouseScrollUp[12];
         char mouseScrollDown[12];
-        char mouseLeftClick[12];
+        char mouseMiddleClick[12];
         char mouseRightClick[12];
         char lastVolume[12];
         char allowNotifications[2];

--- a/src/kew.c
+++ b/src/kew.c
@@ -214,13 +214,13 @@ struct Event processInput()
                 }
 
                 // Received mouse input instead of keyboard input
-                // if (keyMappings[i].seq[0] != '\0' && strnlen(seq, MAX_SEQ_LEN) > 3 && strncmp(seq, "\033[M", 3) == 0 &&
-                //    ((strncmp(seq + 1, keyMappings[i].seq, 3) == 0) ||
-                //      strncmp(seq, keyMappings[i].seq, 3) == 0))
-                // {
-                //         event.type = keyMappings[i].eventType;
-                //         break;
-                // }
+                if (keyMappings[i].seq[0] != '\0' && strnlen(seq, MAX_SEQ_LEN) > 3 && strncmp(seq, "\033[M", 3) == 0 &&
+                   ((strncmp(seq + 1, keyMappings[i].seq, 3) == 0) ||
+                     strncmp(seq, keyMappings[i].seq, 3) == 0))
+                {
+                        event.type = keyMappings[i].eventType;
+                        break;
+                }
         }
 
         // Handle gg

--- a/src/settings.c
+++ b/src/settings.c
@@ -96,7 +96,7 @@ AppSettings constructAppSettings(KeyValuePair *pairs, int count)
         c_strcpy(settings.hardRemove2, "[P", sizeof(settings.hardRemove2));
         c_strcpy(settings.mouseScrollUp, "[M`", sizeof(settings.mouseScrollUp));
         c_strcpy(settings.mouseScrollDown, "[Ma", sizeof(settings.mouseScrollDown));
-        c_strcpy(settings.mouseLeftClick, "[M ", sizeof(settings.mouseLeftClick));
+        c_strcpy(settings.mouseMiddleClick, "[M!", sizeof(settings.mouseMiddleClick));
         c_strcpy(settings.mouseRightClick, "[M\"", sizeof(settings.mouseRightClick));
         c_strcpy(settings.lastVolume, "100", sizeof(settings.lastVolume));
         c_strcpy(settings.color, "6", sizeof(settings.color));
@@ -432,7 +432,7 @@ void mapSettingsToKeys(AppSettings *settings, EventMapping *mappings)
         mappings[47] = (EventMapping){settings->tabNext, EVENT_TABNEXT};
         mappings[48] = (EventMapping){settings->mouseScrollUp, EVENT_SCROLLPREV};
         mappings[49] = (EventMapping){settings->mouseScrollDown, EVENT_SCROLLNEXT};
-        mappings[50] = (EventMapping){settings->mouseLeftClick, EVENT_GOTOSONG};
+        mappings[50] = (EventMapping){settings->mouseMiddleClick, EVENT_GOTOSONG};
         mappings[51] = (EventMapping){settings->mouseRightClick, EVENT_PLAY_PAUSE};
 }
 


### PR DESCRIPTION
Fixes the issue of left clicking to focus causing the song to restart by replacing left click with middle click. This PR also brings back mouse support.

After some testing, I found that the problem with the track view freezing and crashing at the end of the song was not caused by adding mouse support. It could also be caused with the keyboard too. I made an issue for that: https://github.com/ravachol/kew/issues/244

Since the freeze was not cause by adding mouse support, it should be fine to bring it back.