### PR TITLE
Update Play Icon Issue #257

### DIFF
--- a/src/kew.c
+++ b/src/kew.c
@@ -359,6 +359,7 @@ void setEndOfListReached(AppState *state)
         pthread_mutex_lock(&dataSourceMutex);
         cleanupPlaybackDevice();
         pthread_mutex_unlock(&dataSourceMutex);
+        stopped = true;
         refresh = true;
 }
 


### PR DESCRIPTION
When playlist ends, correctly updates "stopped" enabling icon to change to stopped.