### PR TITLE
Prevent visual glitch when clearing playlist - Issue ##264

### DIFF
--- a/src/playerops.c
+++ b/src/playerops.c
@@ -1986,5 +1986,9 @@ void updatePlaylistToPlayingSong(void)
 
         nextSongNeedsRebuilding = true;
         nextSong = NULL;
-        refresh = true;
+        
+        // Only refresh the screen if it makes sense to do so
+        if (appState.currentView == PLAYLIST_VIEW || appState.currentView == LIBRARY_VIEW){
+                refresh = true;
+        }
 }


### PR DESCRIPTION
- When viewing the track if the playlist is cleared, the track display updates which results in a visual refresh.
  This fix sends a refresh only when on playlist or library view.