### PR TITLE
Use correct NUM_KEY_MAPPINGS

### DIFF
--- a/src/settings.h
+++ b/src/settings.h
@@ -20,7 +20,7 @@
 #endif
 
 #ifndef NUM_KEY_MAPPINGS
-#define NUM_KEY_MAPPINGS 57
+#define NUM_KEY_MAPPINGS 58
 #endif
 
 extern AppSettings settings;


### PR DESCRIPTION
Sorry, I messed it up in 1a8942a9802df1cde186e83a35525890c1af5c22 when I added the left click mapping, but forgot to update NUM_KEY_MAPPINGS.