### PR TITLE
Clean up printSpectrum code

### DIFF
--- a/src/visuals.c
+++ b/src/visuals.c
@@ -296,33 +296,31 @@ void printSpectrum(int height, int width, float *magnitudes, PixelData color, in
                 {
                         setDefaultTextColor();
                 }
+
                 if (isPaused() || isStopped())
                 {
                         for (int i = 0; i < width; i++)
                         {
                                 printf("  ");
                         }
+                        printf("\n ");
+                        continue;
                 }
-                else
+
+                for (int i = 0; i < width; i++)
                 {
-                        for (int i = 0; i < width; i++)
+                        if (magnitudes[i] >= j)
                         {
-                                if (j >= 0)
-                                {
-                                        if (magnitudes[i] >= j)
-                                        {
-                                                printf(" %s", getUpwardMotionChar(10));
-                                        }
-                                        else if (magnitudes[i] + 1 >= j)
-                                        {
-                                                int firstDecimalDigit = (int)(fmod(magnitudes[i] * 10, 10));
-                                                printf(" %s", getUpwardMotionChar(firstDecimalDigit));
-                                        }
-                                        else
-                                        {
-                                                printf("  ");
-                                        }
-                                }
+                                printf(" %s", getUpwardMotionChar(10));
+                        }
+                        else if (magnitudes[i] + 1 >= j)
+                        {
+                                int firstDecimalDigit = (int)(fmod(magnitudes[i] * 10, 10));
+                                printf(" %s", getUpwardMotionChar(firstDecimalDigit));
+                        }
+                        else
+                        {
+                                printf("  ");
                         }
                 }
                 printf("\n ");


### PR DESCRIPTION
This PR cleans up the `printSpectrum` function by making it less nested. This PR also removes the `(j >= 0)` check, because `j` is already being checked in the `for` loop, and `j` isn't being modified anywhere.