### PR TITLE
Make removeUnneededChars not check separator characters

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -293,7 +293,7 @@ void removeUnneededChars(char *str)
         bool stringContainsLetters = false;
         while (str[i] != '\0')
         {
-                if (!isdigit(str[i]) && str[i] != '.' && str[i] != '-' && str[i] != ' ')
+                if (!isdigit(str[i]))
                 {
                         stringContainsLetters = true;
                 }


### PR DESCRIPTION
This PR fixes the issue of songs having their numbers displayed if the song contains a separator character. For example, the song `13` by Tally Hall would be displayed as `13 13` instead of just `13`. This PR fixes that.