### PR TITLE
Only remove hyphens and underscore with no spaces around

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -1171,7 +1171,7 @@ void processName(const char *name, char *output, int maxWidth)
         c_strcpy(output, name, copyLength + 1);
 
         output[copyLength] = '\0';
-        removeUnneededChars(output);
+        removeUnneededChars(output, copyLength);
         trim(output, copyLength);
 }
 

--- a/src/playlist_ui.c
+++ b/src/playlist_ui.c
@@ -53,7 +53,7 @@ void preparePlaylistString(Node *node, char *buffer, int bufferSize, int shorten
 
                 c_strcpy(buffer, lastSlash + 1, nameLength + 1);
                 buffer[nameLength] = '\0';
-                removeUnneededChars(buffer);
+                removeUnneededChars(buffer, nameLength);
                 shortenString(buffer, shortenAmount);
                 trim(buffer, MAXPATHLEN);
         }

--- a/src/utils.c
+++ b/src/utils.c
@@ -286,7 +286,7 @@ char *getConfigPath(void)
         return configPath;
 }
 
-void removeUnneededChars(char *str)
+void removeUnneededChars(char *str, int length)
 {
         // Do not remove characters if filename only contains digits
         int i = 0;
@@ -315,12 +315,16 @@ void removeUnneededChars(char *str)
                         }
                         str[j] = '\0';
                         i--; // Decrement i to re-check the current index
+                        length--;
                 }
         }
+
+        // Remove hyphens and underscores from filename
         i = 0;
         while (str[i] != '\0')
         {
-                if (str[i] == '-' || str[i] == '_')
+                // Only remove if there are no spaces around
+                if (str[i] == '-' || str[i] == '_' && (i > 1 && i < length && str[i - 1] != ' ' && str[i + 1] != ' '))
                 {
                         str[i] = ' ';
                 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -56,7 +56,7 @@ const char *getHomePath(void);
 
 char *getConfigPath(void);
 
-void removeUnneededChars(char *str);
+void removeUnneededChars(char *str, int length);
 
 void shortenString(char *str, size_t maxLength);
 


### PR DESCRIPTION
This PR fixes the issue of songs with hyphens or underscores inside their names and spaces around them having them replaced with spaces. For example: Weezer's `Undone - The Sweater Song` would be displayed as `Undone   The Sweater Song`. This PR fixes that issue.