### PR TITLE
Add option to change visualizer color layout

### DIFF
--- a/src/appstate.h
+++ b/src/appstate.h
@@ -56,6 +56,7 @@ typedef struct
         bool hideHelp;                                  // No help text at top
         bool allowNotifications;                        // Send desktop notifications or not
         int visualizerHeight;                           // Height in characters of the spectrum visualizer
+        int visualizerColorType;                        // How colors are laid out in the spectrum visualizer
         int titleDelay;                                 // Delay when drawing title in track view
         int cacheLibrary;                               // Cache the library or not
         bool quitAfterStopping;                         // Exit kew when the music stops or not
@@ -109,6 +110,7 @@ typedef struct
         char useConfigColors[2];
         char visualizerEnabled[2];
         char visualizerHeight[6];
+        char visualizerColorType[2];
         char titleDelay[6];
         char togglePlaylist[6];
         char toggleBindings[6];

--- a/src/kew.c
+++ b/src/kew.c
@@ -1662,6 +1662,7 @@ void initState(AppState *state)
         state->uiSettings.hideGlimmeringText = false;
         state->uiSettings.coverAnsi = false;
         state->uiSettings.visualizerHeight = 5;
+        state->uiSettings.visualizerColorType = 0;
         state->uiSettings.titleDelay = 9;
         state->uiSettings.cacheLibrary = -1;
         state->uiSettings.useConfigColors = false;

--- a/src/player.c
+++ b/src/player.c
@@ -1095,7 +1095,7 @@ void printVisualizer(double elapsedSeconds, AppState *state)
 #ifndef __APPLE__
                 saveCursorPosition();
 #endif
-                drawSpectrumVisualizer(ui->visualizerHeight, visualizerWidth, ui->color, indent, ui->useConfigColors);
+                drawSpectrumVisualizer(ui->visualizerHeight, visualizerWidth, ui->color, indent, ui->useConfigColors, ui->visualizerColorType);
                 printElapsedBars(calcElapsedBars(elapsedSeconds, duration, uis->numProgressBars), uis->numProgressBars);
                 printErrorRow();
                 printLastRow(&state->uiSettings);

--- a/src/settings.c
+++ b/src/settings.c
@@ -49,6 +49,7 @@ AppSettings constructAppSettings(KeyValuePair *pairs, int count)
         c_strcpy(settings.hideHelp, "0", sizeof(settings.hideHelp));
         c_strcpy(settings.cacheLibrary, "-1", sizeof(settings.cacheLibrary));
         c_strcpy(settings.visualizerHeight, "5", sizeof(settings.visualizerHeight));
+        c_strcpy(settings.visualizerColorType, "0", sizeof(settings.visualizerColorType));
         c_strcpy(settings.titleDelay, "9", sizeof(settings.titleDelay));
 
         c_strcpy(settings.nextView, "\t", sizeof(settings.nextView));
@@ -160,6 +161,10 @@ AppSettings constructAppSettings(KeyValuePair *pairs, int count)
                 else if (strcmp(lowercaseKey, "visualizerheight") == 0)
                 {
                         snprintf(settings.visualizerHeight, sizeof(settings.visualizerHeight), "%s", pair->value);
+                }
+                else if (strcmp(lowercaseKey, "visualizercolortype") == 0)
+                {
+                        snprintf(settings.visualizerColorType, sizeof(settings.visualizerColorType), "%s", pair->value);
                 }
                 else if (strcmp(lowercaseKey, "titledelay") == 0)
                 {
@@ -679,6 +684,10 @@ void getConfig(AppSettings *settings, UISettings *ui)
         if (temp > 0)
                 ui->visualizerHeight = temp;
 
+        temp = getNumber(settings->visualizerColorType);
+        if (temp > 0)
+                ui->visualizerColorType = temp;
+
         temp = getNumber(settings->titleDelay);
         if (temp >= 0)
                 ui->titleDelay = temp;
@@ -733,6 +742,8 @@ void setConfig(AppSettings *settings, UISettings *ui)
 
         if (settings->visualizerHeight[0] == '\0')
                 snprintf(settings->visualizerHeight, sizeof(settings->visualizerHeight), "%d", ui->visualizerHeight);
+        if (settings->visualizerColorType[0] == '\0')
+                snprintf(settings->visualizerColorType, sizeof(settings->visualizerColorType), "%d", ui->visualizerColorType);
         if (settings->titleDelay[0] == '\0')
                 snprintf(settings->titleDelay, sizeof(settings->titleDelay), "%d", ui->titleDelay);
         if (settings->cacheLibrary[0] == '\0')
@@ -778,6 +789,8 @@ void setConfig(AppSettings *settings, UISettings *ui)
         fprintf(file, "coverAnsi=%s\n", settings->coverAnsi);
         fprintf(file, "visualizerEnabled=%s\n", settings->visualizerEnabled);
         fprintf(file, "visualizerHeight=%s\n", settings->visualizerHeight);
+        fprintf(file, "# How colors are laid out in the spectrum visualizer. 0 for default, or 1 for brightness to change depending on bar height.\n");
+        fprintf(file, "visualizerColorType=%s\n", settings->visualizerColorType);
         fprintf(file, "useConfigColors=%s\n", settings->useConfigColors);
         fprintf(file, "allowNotifications=%s\n", settings->allowNotifications);
         fprintf(file, "hideLogo=%s\n", settings->hideLogo);

--- a/src/visuals.c
+++ b/src/visuals.c
@@ -274,7 +274,7 @@ PixelData increaseLuminosity(PixelData pixel, int amount)
         return pixel2;
 }
 
-void printSpectrum(int height, int width, float *magnitudes, PixelData color, int indentation, bool useConfigColors)
+void printSpectrum(int height, int width, float *magnitudes, PixelData color, int indentation, bool useConfigColors, int visualizerColorType)
 {
         printf("\n");
 
@@ -286,7 +286,7 @@ void printSpectrum(int height, int width, float *magnitudes, PixelData color, in
                 printBlankSpaces(indentation);
                 if (color.r != 0 || color.g != 0 || color.b != 0)
                 {
-                        if (!useConfigColors)
+                        if (!useConfigColors && visualizerColorType == 0)
                         {
                                 tmp = increaseLuminosity(color, round(j * height * 4));
                                 printf("\033[38;2;%d;%d;%dm", tmp.r, tmp.g, tmp.b);
@@ -309,6 +309,14 @@ void printSpectrum(int height, int width, float *magnitudes, PixelData color, in
 
                 for (int i = 0; i < width; i++)
                 {
+                        if (!useConfigColors && visualizerColorType == 1)
+                        {
+                                // Make colors half as bright before increasing brightness
+                                tmp = (PixelData){ color.r / 2, color.g / 2, color.b / 2 };
+                                tmp = increaseLuminosity(color, round(magnitudes[i] * 10 * 4));
+                                printf("\033[38;2;%d;%d;%dm", tmp.r, tmp.g, tmp.b);
+                        }
+
                         if (magnitudes[i] >= j)
                         {
                                 printf(" %s", getUpwardMotionChar(10));
@@ -343,7 +351,7 @@ void freeVisuals(void)
         }
 }
 
-void drawSpectrumVisualizer(int height, int width, PixelData c, int indentation, bool useConfigColors)
+void drawSpectrumVisualizer(int height, int width, PixelData c, int indentation, bool useConfigColors, int visualizerColorType)
 {
         bufferSize = getBufferSize();
         PixelData color;
@@ -394,7 +402,7 @@ void drawSpectrumVisualizer(int height, int width, PixelData c, int indentation,
 
         calcSpectrum(height, numBars, fftInput, fftOutput, magnitudes, plan);
 
-        printSpectrum(height, numBars, magnitudes, color, indentation, useConfigColors);
+        printSpectrum(height, numBars, magnitudes, color, indentation, useConfigColors, visualizerColorType);
 
         fftwf_destroy_plan(plan);
 }

--- a/src/visuals.h
+++ b/src/visuals.h
@@ -24,6 +24,6 @@ void initVisuals(void);
 
 void freeVisuals(void);
 
-void drawSpectrumVisualizer(int height, int width, PixelData c, int indentation, bool useConfigColors);
+void drawSpectrumVisualizer(int height, int width, PixelData c, int indentation, bool useConfigColors, int visualizerColorType);
 
 PixelData increaseLuminosity(PixelData pixel, int amount);


### PR DESCRIPTION
This PR adds an option in the config file to make the visualizer look like this (the default):

<img src="https://github.com/user-attachments/assets/28da766c-71cf-4e66-85fd-8bc3c2856a5a" width=500/>

Or this:

<img src="https://github.com/user-attachments/assets/2f96cba5-71a8-4719-a77a-94d157604c68" width=500/>

In the second image, the brightness of the bar depends on the height.