### PR TITLE
Make sure elapsed bars are a single color

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -1055,10 +1055,17 @@ void resetRadioSearchResult(void)
         chosenRadioSearchResultRow = 0;
 }
 
-void printElapsedBars(int elapsedBars, int numProgressBars, PixelData color, int height)
+void printElapsedBars(int elapsedBars, int numProgressBars, PixelData color, int height, bool useConfigColors)
 {
-        PixelData tmp = increaseLuminosity(color, round(height * 4));
-        printf("\033[38;2;%d;%d;%dm", tmp.r, tmp.g, tmp.b);
+        if (!useConfigColors)
+        {
+                PixelData tmp = increaseLuminosity(color, round(height * 4));
+                printf("\033[38;2;%d;%d;%dm", tmp.r, tmp.g, tmp.b);
+        }
+        else
+        {
+                setDefaultTextColor();
+        }
         printBlankSpaces(indent);
         printf(" ");
         for (int i = 0; i < numProgressBars; i++)
@@ -1098,7 +1105,7 @@ void printVisualizer(double elapsedSeconds, AppState *state)
                 saveCursorPosition();
 #endif
                 drawSpectrumVisualizer(ui->visualizerHeight, visualizerWidth, ui->color, indent, ui->useConfigColors, ui->visualizerColorType);
-                printElapsedBars(calcElapsedBars(elapsedSeconds, duration, uis->numProgressBars), uis->numProgressBars, ui->color, ui->visualizerHeight);
+                printElapsedBars(calcElapsedBars(elapsedSeconds, duration, uis->numProgressBars), uis->numProgressBars, ui->color, ui->visualizerHeight, ui->useConfigColors);
                 printErrorRow();
                 printLastRow(&state->uiSettings);
 #ifndef __APPLE__

--- a/src/player.c
+++ b/src/player.c
@@ -1055,8 +1055,10 @@ void resetRadioSearchResult(void)
         chosenRadioSearchResultRow = 0;
 }
 
-void printElapsedBars(int elapsedBars, int numProgressBars)
+void printElapsedBars(int elapsedBars, int numProgressBars, PixelData color, int height)
 {
+        PixelData tmp = increaseLuminosity(color, round(height * 4));
+        printf("\033[38;2;%d;%d;%dm", tmp.r, tmp.g, tmp.b);
         printBlankSpaces(indent);
         printf(" ");
         for (int i = 0; i < numProgressBars; i++)
@@ -1096,7 +1098,7 @@ void printVisualizer(double elapsedSeconds, AppState *state)
                 saveCursorPosition();
 #endif
                 drawSpectrumVisualizer(ui->visualizerHeight, visualizerWidth, ui->color, indent, ui->useConfigColors, ui->visualizerColorType);
-                printElapsedBars(calcElapsedBars(elapsedSeconds, duration, uis->numProgressBars), uis->numProgressBars);
+                printElapsedBars(calcElapsedBars(elapsedSeconds, duration, uis->numProgressBars), uis->numProgressBars, ui->color, ui->visualizerHeight);
                 printErrorRow();
                 printLastRow(&state->uiSettings);
 #ifndef __APPLE__

--- a/src/visuals.c
+++ b/src/visuals.c
@@ -311,9 +311,8 @@ void printSpectrum(int height, int width, float *magnitudes, PixelData color, in
                 {
                         if (!useConfigColors && visualizerColorType == 1)
                         {
-                                // Make colors half as bright before increasing brightness
-                                tmp = (PixelData){ color.r / 2, color.g / 2, color.b / 2 };
-                                tmp = increaseLuminosity(color, round(magnitudes[i] * 10 * 4));
+                                tmp = (PixelData){ color.r / 2, color.g / 2, color.b / 2 }; // Make colors half as bright before increasing brightness
+                                tmp = increaseLuminosity(tmp, round(magnitudes[i] * 10 * 4));
                                 printf("\033[38;2;%d;%d;%dm", tmp.r, tmp.g, tmp.b);
                         }
 


### PR DESCRIPTION
This PR sets the color before printing the elapsed bars, because having visualizerColorType set to 1 could make the elapsed bars different colors.

This PR also makes the colors when having visualizerColorType set to 1 look a little nicer.