### PR TITLE
Do not cut last 2 characters in title in track view

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -379,7 +379,7 @@ void printBasicMetadata(TagSettings const *metadata, UISettings *ui)
                         printf("\033[1;38;2;%03u;%03u;%03um", pixel.r, pixel.g, pixel.b);
                 }
 
-                printTitleWithDelay(metadata->title, ui->titleDelay, maxWidth - 2);
+                printTitleWithDelay(metadata->title, ui->titleDelay, maxWidth);
         }
         else
         {


### PR DESCRIPTION
When songs have names longer than the minimum width, the last 2 characters are removed when displayed in track view. This PR fixes this.