### PR TITLE
Small cleanup

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -292,9 +292,7 @@ void printCover(SongData *songdata, UISettings *ui)
 
 void printTitleWithDelay(const char *text, int delay, int maxWidth)
 {
-        int length = strnlen(text, maxWidth);
-        int max = (maxWidth > length) ? length : maxWidth;
-
+        int max = strnlen(text, maxWidth);
         max -= 2; // accommodate for the cursor that we display after the name.
 
         for (int i = 0; i <= max; i++)


### PR DESCRIPTION
The ternary operator for setting `max` is redundant. `strnlen` makes sure the length is no more than `maxWidth`.