### PR TITLE
Add config option to disable mouse

### DIFF
--- a/src/appstate.h
+++ b/src/appstate.h
@@ -39,6 +39,7 @@ typedef struct
         int titleColor;                                 // Color of the title, when using config colors
         int artistColor;                                // Artist color, when using config colors
         int enqueuedColor;                              // Color of enqueued files, when using config colors
+        bool mouseEnabled;                              // Accept mouse input or not
         int mouseLeftClickAction;                       // Left mouse action
         int mouseMiddleClickAction;                     // Middle mouse action
         int mouseRightClickAction;                      // Right mouse action
@@ -179,6 +180,7 @@ typedef struct
         char artistColor[2];
         char enqueuedColor[2];
         char titleColor[2];
+        char mouseEnabled[2];
         char mouseLeftClickAction[3];
         char mouseMiddleClickAction[3];
         char mouseRightClickAction[3];

--- a/src/kew.c
+++ b/src/kew.c
@@ -1281,7 +1281,8 @@ void cleanupOnExit()
         printf("\n");
         showCursor();
         exitAlternateScreenBuffer();
-        disableMouseButtons();
+        if (appState.uiSettings.mouseEnabled)
+                disableMouseButtons();
 
         if (noMusicFound)
         {
@@ -1712,6 +1713,7 @@ void initState(AppState *state)
         state->uiSettings.titleDelay = 9;
         state->uiSettings.cacheLibrary = -1;
         state->uiSettings.useConfigColors = false;
+        state->uiSettings.mouseEnabled = true;
         state->uiState.numDirectoryTreeEntries = 0;
         state->uiState.numProgressBars = 35;
         state->uiState.chosenNodeId = 0;
@@ -1752,7 +1754,8 @@ int main(int argc, char *argv[])
                 exit(0);
         }
 
-        enableMouseButtons();
+        if (ui->mouseEnabled)
+                enableMouseButtons();
 
         initializeStateAndSettings(&appState, &settings);
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -38,6 +38,7 @@ AppSettings constructAppSettings(KeyValuePair *pairs, int count)
         c_strcpy(settings.coverAnsi, "0", sizeof(settings.coverAnsi));
         c_strcpy(settings.quitAfterStopping, "0", sizeof(settings.quitAfterStopping));
         c_strcpy(settings.hideGlimmeringText, "0", sizeof(settings.hideGlimmeringText));
+        c_strcpy(settings.mouseEnabled, "1", sizeof(settings.mouseEnabled));
 #ifdef __APPLE__
         c_strcpy(settings.visualizerEnabled, "0", sizeof(settings.visualizerEnabled)); // visualizer looks wonky in default terminal
         c_strcpy(settings.useConfigColors, "1", sizeof(settings.useConfigColors));     // colors from album look wrong in default terminal
@@ -265,6 +266,10 @@ AppSettings constructAppSettings(KeyValuePair *pairs, int count)
                 else if (strcmp(lowercaseKey, "titlecolor") == 0)
                 {
                         snprintf(settings.titleColor, sizeof(settings.titleColor), "%s", pair->value);
+                }
+                else if (strcmp(lowercaseKey, "mouseenabled") == 0)
+                {
+                        snprintf(settings.mouseEnabled, sizeof(settings.mouseEnabled), "%s", pair->value);
                 }
                 else if (strcmp(lowercaseKey, "mouseleftclickaction") == 0)
                 {
@@ -632,6 +637,7 @@ void getConfig(AppSettings *settings, UISettings *ui)
         ui->useConfigColors = (settings->useConfigColors[0] == '1');
         ui->quitAfterStopping = (settings->quitAfterStopping[0] == '1');
         ui->hideGlimmeringText = (settings->hideGlimmeringText[0] == '1');
+        ui->mouseEnabled = (settings->mouseEnabled[0] == '1');
         ui->hideLogo = (settings->hideLogo[0] == '1');
         ui->hideHelp = (settings->hideHelp[0] == '1');
 
@@ -741,6 +747,8 @@ void setConfig(AppSettings *settings, UISettings *ui)
                 ui->quitAfterStopping ? c_strcpy(settings->quitAfterStopping, "1", sizeof(settings->quitAfterStopping)) : c_strcpy(settings->quitAfterStopping, "0", sizeof(settings->quitAfterStopping));
         if (settings->hideGlimmeringText[0] == '\0')
                 ui->hideGlimmeringText ? c_strcpy(settings->hideGlimmeringText, "1", sizeof(settings->hideGlimmeringText)) : c_strcpy(settings->hideGlimmeringText, "0", sizeof(settings->hideGlimmeringText));
+        if (settings->mouseEnabled[0] == '\0')
+                ui->mouseEnabled ? c_strcpy(settings->mouseEnabled, "1", sizeof(settings->mouseEnabled)) : c_strcpy(settings->mouseEnabled, "0", sizeof(settings->mouseEnabled));
         if (settings->hideLogo[0] == '\0')
                 ui->hideLogo ? c_strcpy(settings->hideLogo, "1", sizeof(settings->hideLogo)) : c_strcpy(settings->hideLogo, "0", sizeof(settings->hideLogo));
         if (settings->hideHelp[0] == '\0')
@@ -825,6 +833,8 @@ void setConfig(AppSettings *settings, UISettings *ui)
         fprintf(file, "titleColor=%s\n", settings->titleColor);
         fprintf(file, "# Color of enqueued songs in library view:\n");
         fprintf(file, "enqueuedColor=%s\n", settings->enqueuedColor);
+
+        fprintf(file, "\nmouseEnabled=%s\n", settings->mouseEnabled);
 
         fprintf(file, "\n# Mouse actions are 0=none, 1=select song, 2=toggle pause, 3=scroll up, 4=scroll down, 5=seek forward, 6=seek backward, 7=volume up, 8=volume down, 9=switch to next view, 10=switch to previous view\n");
         fprintf(file, "mouseLeftClickAction=%s\n", settings->mouseLeftClickAction);

--- a/src/settings.h
+++ b/src/settings.h
@@ -25,8 +25,6 @@
 
 extern AppSettings settings;
 
-enum EventType getMouseAction(int num);
-
 void getConfig(AppSettings *settings, UISettings *ui);
 
 void setConfig(AppSettings *settings, UISettings *ui);


### PR DESCRIPTION
When you're testing this, if you're using Konsole, scrolling up and down may still work. I have no idea why Konsole does this, even when it is not sent the ansi code to use mouse ("\033[?1002h"). All the other terminals I tested showed the expected behavior of not responding to the mouse, except Konsole. I'm using Debian 12 Stable, so it may be fixed, let me know if it happens to you too.