### PR TITLE
Cleanup

### DIFF
--- a/src/directorytree.c
+++ b/src/directorytree.c
@@ -417,9 +417,9 @@ int utf8_levenshteinDistance(const char *s1, const char *s2)
                         int cost = (c1 == c2) ? 0 : 1;
 
                         // Fill the current row with the minimum of deletion, insertion, or substitution
-                        currRow[j] = MIN(prevRow[j] + 1,              // deletion
-                                         MIN(currRow[j - 1] + 1,      // insertion
-                                             prevRow[j - 1] + cost)); // substitution
+                        currRow[j] = MIN(prevRow[j] + 1,              // Deletion
+                                         MIN(currRow[j - 1] + 1,      // Insertion
+                                             prevRow[j - 1] + cost)); // Substitution
                 }
 
                 // Swap rows (current becomes previous for the next iteration)

--- a/src/kew.c
+++ b/src/kew.c
@@ -158,7 +158,7 @@ struct Event processInput()
                     strcmp(seq + 1, settings.hardNextPage) == 0 || strcmp(seq + 1, settings.hardPrevPage) == 0)
                 {
                         keyReleased = 0;
-                        readInputSequence(tmpSeq, sizeof(tmpSeq)); // dummy read to prevent scrolling after key released
+                        readInputSequence(tmpSeq, sizeof(tmpSeq)); // Dummy read to prevent scrolling after key released
                         break;
                 }
 
@@ -372,7 +372,7 @@ void notifyMPRISSwitch(SongData *currentSongData)
 
         gint64 length = getLengthInMicroSec(currentSongData->duration);
 
-        // update mpris
+        // Update mpris
         emitMetadataChanged(
             currentSongData->metadata->title,
             currentSongData->metadata->artist,
@@ -541,7 +541,7 @@ FileSystemEntry *enqueue(AppState *state, FileSystemEntry *entry)
 
         pthread_mutex_lock(&(playlist.mutex));
 
-        firstEnqueuedEntry = enqueueSongs(entry, &state->uiState);
+        firstEnqueuedEntry = enqueueSongs(entry, &(state->uiState));
         resetListAfterDequeuingPlayingSong(state);
 
         pthread_mutex_unlock(&(playlist.mutex));
@@ -601,7 +601,7 @@ void handleGoToSong(AppState *state)
 
                 setChosenDir(entry);
 
-                enqueueSongs(entry, &state->uiState);
+                enqueueSongs(entry, &(state->uiState));
 
                 resetListAfterDequeuingPlayingSong(state);
 
@@ -909,7 +909,7 @@ void updatePlayer(UIState *uis)
         struct winsize ws;
         ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws);
 
-        // check if window has changed size
+        // Check if window has changed size
         if (ws.ws_col != windowSize.ws_col || ws.ws_row != windowSize.ws_row)
         {
                 uis->resizeFlag = 1;
@@ -1011,7 +1011,7 @@ void loadAudioData(AppState *state)
         else if (currentSong != NULL && (nextSongNeedsRebuilding || nextSong == NULL) && !songLoading)
         {
                 loadNextSong();
-                determineSongAndNotify(&state->uiSettings);
+                determineSongAndNotify(&(state->uiSettings));
         }
 }
 
@@ -1100,7 +1100,7 @@ void handleSkipFromStopped()
 
 void updatePlayerStatus(AppState *state)
 {
-        updatePlayer(&state->uiState);
+        updatePlayer(&(state->uiState));
 
         reconnectRadioIfNeeded();
 
@@ -1251,12 +1251,12 @@ void cleanupOnExit()
         if (!userData.songdataADeleted)
         {
                 userData.songdataADeleted = true;
-                unloadSongData(&loadingdata.songdataA, &appState);
+                unloadSongData(&(loadingdata.songdataA), &appState);
         }
         if (!userData.songdataBDeleted)
         {
                 userData.songdataBDeleted = true;
-                unloadSongData(&loadingdata.songdataB, &appState);
+                unloadSongData(&(loadingdata.songdataB), &appState);
         }
 
         freeSearchResults();
@@ -1356,7 +1356,7 @@ void initResize()
 
         struct sigaction sa;
         sa.sa_handler = resetResizeFlag;
-        sigemptyset(&sa.sa_mask);
+        sigemptyset(&(sa.sa_mask));
         sa.sa_flags = 0;
         sigaction(SIGALRM, &sa, NULL);
 }
@@ -1760,9 +1760,9 @@ void initState(AppState *state)
 void initializeStateAndSettings(AppState *appState, AppSettings *settings)
 {
         initState(appState);
-        getConfig(settings, &appState->uiSettings);
-        mapSettingsToKeys(settings, &appState->uiSettings, keyMappings);
-        enableMouse(&appState->uiSettings);
+        getConfig(settings, &(appState->uiSettings));
+        mapSettingsToKeys(settings, &(appState->uiSettings), keyMappings);
+        enableMouse(&(appState->uiSettings));
 }
 
 int main(int argc, char *argv[])

--- a/src/m4a.h
+++ b/src/m4a.h
@@ -28,14 +28,14 @@ extern "C"
         {
                 k_unknown = 0,
                 k_aac = 1,
-                k_rawAAC = 2, // raw aac (.aac file) decoding is included here for convenience although they are not .m4a files
+                k_rawAAC = 2, // Raw aac (.aac file) decoding is included here for convenience although they are not .m4a files
                 k_ALAC = 3,
                 k_FLAC = 4
         } k_m4adec_filetype;
 
         typedef struct
         {
-                ma_data_source_base ds; /* The m4a decoder can be used independently as a data source. */
+                ma_data_source_base ds; // The m4a decoder can be used independently as a data source.
                 ma_read_proc onRead;
                 ma_seek_proc onSeek;
                 ma_tell_proc onTell;
@@ -421,7 +421,7 @@ extern "C"
                                 if (atom_size_out)
                                         *atom_size_out = atom_size - 8;
 
-                                return 1; // found
+                                return 1; // Found
                         }
 
                         if (fseek(fp, atom_size - 8, SEEK_CUR) != 0)
@@ -478,25 +478,25 @@ extern "C"
                 if (!find_atom(fp, FOUR_CHAR_INT('s', 't', 's', 'd'), atom_size, &atom_size))
                         return 0;
 
-                fseek(fp, 8, SEEK_CUR); // skip stsd header (version+entry)
+                fseek(fp, 8, SEEK_CUR); // Skip stsd header (version+entry)
 
                 read_u32be(fp); // uint32_t sample_entry_size
                 uint32_t sample_entry_fourcc = read_u32be(fp);
                 if (sample_entry_fourcc != FOUR_CHAR_INT('a', 'l', 'a', 'c'))
                         return 0;
 
-                fseek(fp, 28, SEEK_CUR); // skip audio sample entry fields
+                fseek(fp, 28, SEEK_CUR); // Skip audio sample entry fields
 
                 uint32_t config_atom_size = read_u32be(fp);
                 uint32_t config_atom_fourcc = read_u32be(fp);
                 if (config_atom_fourcc != FOUR_CHAR_INT('a', 'l', 'a', 'c'))
                         return 0;
 
-                fseek(fp, 4, SEEK_CUR); // skip 1-byte version and 3-byte flags (4 bytes total)!
+                fseek(fp, 4, SEEK_CUR); // Skip 1-byte version and 3-byte flags (4 bytes total)!
 
                 uint32_t alac_dsi_size = config_atom_size - 12; // size(4)+fourcc(4)+version/flags(4) total=12 bytes overhead
                 if (alac_dsi_size < 24 || alac_dsi_size > 64)
-                        return 0; // sanity check
+                        return 0; // Sanity check
 
                 if (fread(dsi_out, 1, alac_dsi_size, fp) != alac_dsi_size)
                         return 0;

--- a/src/mpris.c
+++ b/src/mpris.c
@@ -1116,7 +1116,7 @@ gchar *sanitizeTitle(const gchar *title)
         // Replace underscores with hyphens, otherwise some widgets have a problem
         g_strdelimit(sanitized, "_", '-');
 
-        // duplicate string otherwise widgets have a problem with certain strings for some reason
+        // Duplicate string otherwise widgets have a problem with certain strings for some reason
         gchar *sanitized_dup = g_strdup_printf("%s", sanitized);
 
         g_free(sanitized);

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -170,12 +170,12 @@ typedef struct
 
 static void bus_connection_data_ref(BusConnectionData *data)
 {
-        g_atomic_int_inc(&data->ref_count);
+        g_atomic_int_inc(&(data->ref_count));
 }
 
 static void bus_connection_data_unref(BusConnectionData *data)
 {
-        if (g_atomic_int_dec_and_test(&data->ref_count))
+        if (g_atomic_int_dec_and_test(&(data->ref_count)))
         {
                 g_main_loop_unref(data->loop);
                 g_free(data);

--- a/src/player.c
+++ b/src/player.c
@@ -661,7 +661,7 @@ void printLastRow(UISettings *ui)
                 currentLength += strnlen(rewindText, maxLength - currentLength);
         }
 
-        printf("\033[K"); // clear the line
+        printf("\033[K"); // Clear the line
 
         int indent = calcIndentNormal();
         int textLength = strnlen(text, 100);
@@ -1049,7 +1049,7 @@ void showPlaylist(SongData *songData, PlayList *list, int *chosenSong, int *chos
         if (state->uiSettings.useConfigColors)
                 setTextColor(state->uiSettings.artistColor);
         else
-                setColor(&state->uiSettings);
+                setColor(&(state->uiSettings));
 
         printBlankSpaces(indent);
         printf("   ─ PLAYLIST ─\n");
@@ -1058,7 +1058,7 @@ void showPlaylist(SongData *songData, PlayList *list, int *chosenSong, int *chos
         displayPlaylist(list, maxListSize, indent, chosenSong, chosenNodeId, state->uiState.resetPlaylistDisplay, state);
 
         printErrorRow();
-        printLastRow(&state->uiSettings);
+        printLastRow(&(state->uiSettings));
 }
 
 void resetSearchResult(void)
@@ -1123,7 +1123,7 @@ void printVisualizer(double elapsedSeconds, AppState *state)
                 drawSpectrumVisualizer(ui->visualizerHeight, visualizerWidth, ui->color, indent, ui->useConfigColors, ui->visualizerColorType);
                 printElapsedBars(calcElapsedBars(elapsedSeconds, duration, uis->numProgressBars), uis->numProgressBars, ui->color, ui->visualizerHeight, ui->useConfigColors);
                 printErrorRow();
-                printLastRow(&state->uiSettings);
+                printLastRow(&(state->uiSettings));
 #ifndef __APPLE__
                 restoreCursorPosition();
                 cursorJump(1);
@@ -1582,7 +1582,7 @@ int printPlayer(SongData *songdata, double elapsedSeconds, AppSettings *settings
         else if (state->currentView == PLAYLIST_VIEW && refresh)
         {
                 clearScreen();
-                showPlaylist(songdata, originalPlaylist, &chosenRow, &uis->chosenNodeId, state);
+                showPlaylist(songdata, originalPlaylist, &chosenRow, &(uis->chosenNodeId), state);
                 state->uiState.resetPlaylistDisplay = false;
                 refresh = false;
                 fflush(stdout);

--- a/src/playerops.c
+++ b/src/playerops.c
@@ -185,7 +185,7 @@ void play(Node *song)
         songLoading = true;
         forceSkip = false;
 
-        // cancel starting from top
+        // Cancel starting from top
         if (waitingForPlaylist || audioData.restart)
         {
                 waitingForPlaylist = false;
@@ -352,7 +352,7 @@ void addToSpecialPlaylist(void)
 
         Node *node = NULL;
 
-        if (findSelectedEntryById(specialPlaylist, id) != NULL) // song is already in list
+        if (findSelectedEntryById(specialPlaylist, id) != NULL) // Song is already in list
                 return;
 
         createNode(&node, currentSong->song.filePath, id);
@@ -1032,7 +1032,7 @@ void dequeueSong(FileSystemEntry *child)
 
         child->isEnqueued = 0;
 
-        // check if parent needs to be dequeued as well
+        // Check if parent needs to be dequeued as well
         bool isEnqueued = false;
 
         FileSystemEntry *ch = child->parent->children;
@@ -1358,7 +1358,7 @@ int loadDecoder(SongData *songData, bool *songDataDeleted)
         {
                 *songDataDeleted = false;
 
-                // this should only be done for the second song, as switchAudioImplementation() handles the first one
+                // This should only be done for the second song, as switchAudioImplementation() handles the first one
                 if (!loadingdata.loadingFirstDecoder)
                 {
                         if (hasBuiltinDecoder(songData->filePath))
@@ -1384,12 +1384,12 @@ int assignLoadedData(void)
         if (loadingdata.loadA)
         {
                 userData.songdataA = loadingdata.songdataA;
-                result = loadDecoder(loadingdata.songdataA, &userData.songdataADeleted);
+                result = loadDecoder(loadingdata.songdataA, &(userData.songdataADeleted));
         }
         else
         {
                 userData.songdataB = loadingdata.songdataB;
-                result = loadDecoder(loadingdata.songdataB, &userData.songdataBDeleted);
+                result = loadDecoder(loadingdata.songdataB, &(userData.songdataBDeleted));
         }
 
         return result;
@@ -1412,7 +1412,7 @@ void *songDataReaderThread(void *arg)
                 if (!userData.songdataADeleted)
                 {
                         userData.songdataADeleted = true;
-                        unloadSongData(&loadingdata->songdataA, &appState);
+                        unloadSongData(&(loadingdata->songdataA), &appState);
                 }
         }
         else
@@ -1420,7 +1420,7 @@ void *songDataReaderThread(void *arg)
                 if (!userData.songdataBDeleted)
                 {
                         userData.songdataBDeleted = true;
-                        unloadSongData(&loadingdata->songdataB, &appState);
+                        unloadSongData(&(loadingdata->songdataB), &appState);
                 }
         }
 
@@ -1706,7 +1706,7 @@ void skipToPrevSong(AppState *state)
         if (song == currentSong)
         {
                 resetTimeCount();
-                updatePlaybackPosition(0); // we need to signal to mpris that the song was reset to the beginning
+                updatePlaybackPosition(0); // We need to signal to mpris that the song was reset to the beginning
         }
 
         playbackPlay(&totalPauseSeconds, &pauseSeconds);
@@ -1820,7 +1820,7 @@ void unloadSongA(AppState *state)
         if (userData.songdataADeleted == false)
         {
                 userData.songdataADeleted = true;
-                unloadSongData(&loadingdata.songdataA, state);
+                unloadSongData(&(loadingdata.songdataA), state);
                 userData.songdataA = NULL;
         }
 }
@@ -1830,7 +1830,7 @@ void unloadSongB(AppState *state)
         if (userData.songdataBDeleted == false)
         {
                 userData.songdataBDeleted = true;
-                unloadSongData(&loadingdata.songdataB, state);
+                unloadSongData(&(loadingdata.songdataB), state);
                 userData.songdataB = NULL;
         }
 }
@@ -1867,7 +1867,7 @@ void unloadPreviousSong(AppState *state)
 
 int loadFirst(Node *song, AppState *state)
 {
-        loadFirstSong(song, &state->uiSettings);
+        loadFirstSong(song, &(state->uiSettings));
 
         usingSongDataA = true;
 
@@ -1876,12 +1876,12 @@ int loadFirst(Node *song, AppState *state)
                 songHasErrors = false;
                 loadedNextSong = false;
                 currentSong = currentSong->next;
-                loadFirstSong(currentSong, &state->uiSettings);
+                loadFirstSong(currentSong, &(state->uiSettings));
         }
 
         if (songHasErrors)
         {
-                // couldn't play any of the songs
+                // Couldn't play any of the songs
                 unloadPreviousSong(state);
                 currentSong = NULL;
                 songHasErrors = false;
@@ -1982,7 +1982,7 @@ void createLibrary(AppSettings *settings, AppState *state)
         if (state->uiSettings.cacheLibrary > 0)
         {
                 char *libFilepath = getLibraryFilePath();
-                library = reconstructTreeFromFile(libFilepath, settings->path, &state->uiState.numDirectoryTreeEntries);
+                library = reconstructTreeFromFile(libFilepath, settings->path, &(state->uiState.numDirectoryTreeEntries));
                 free(libFilepath);
                 updateLibraryIfChangedDetected();
         }
@@ -1993,7 +1993,7 @@ void createLibrary(AppSettings *settings, AppState *state)
 
                 gettimeofday(&start, NULL);
 
-                library = createDirectoryTree(settings->path, &state->uiState.numDirectoryTreeEntries);
+                library = createDirectoryTree(settings->path, &(state->uiState.numDirectoryTreeEntries));
 
                 gettimeofday(&end, NULL);
                 long seconds = end.tv_sec - start.tv_sec;
@@ -2003,7 +2003,7 @@ void createLibrary(AppSettings *settings, AppState *state)
                 // If time to load the library was significant, ask to use cache instead
                 if (elapsed > ASK_IF_USE_CACHE_LIMIT_SECONDS)
                 {
-                        askIfCacheLibrary(&state->uiSettings);
+                        askIfCacheLibrary(&(state->uiSettings));
                 }
         }
 
@@ -2113,7 +2113,7 @@ void updateLibraryIfChangedDetected(void)
         }
 
         args->path = settings.path;
-        args->ui = &appState.uiSettings;
+        args->ui = &(appState.uiSettings);
 
         if (pthread_create(&tid, NULL, updateIfTopLevelFoldersMtimesChangedThread, (void *)args) != 0)
         {

--- a/src/search_ui.c
+++ b/src/search_ui.c
@@ -27,7 +27,7 @@ size_t resultsCapacity = 0;
 int minSearchLetters = 1;
 FileSystemEntry *currentSearchEntry = NULL;
 
-char searchText[MAX_SEARCH_LEN * 4 + 1]; // unicode can be 4 characters
+char searchText[MAX_SEARCH_LEN * 4 + 1]; // Unicode can be 4 characters
 
 FileSystemEntry *getCurrentSearchEntry(void)
 {

--- a/src/searchradio_ui.c
+++ b/src/searchradio_ui.c
@@ -32,7 +32,7 @@ RadioSearchResult *playingRadioSearchEntry = NULL;
 
 RadioSearchResult *currentPlayingRadioStation = NULL;
 
-char radioSearchText[MAX_SEARCH_LEN * 4 + 1]; // unicode can be 4 characters
+char radioSearchText[MAX_SEARCH_LEN * 4 + 1]; // Unicode can be 4 characters
 
 RadioSearchResult *getCurrentRadioSearchEntry(void)
 {

--- a/src/settings.c
+++ b/src/settings.c
@@ -40,8 +40,8 @@ AppSettings constructAppSettings(KeyValuePair *pairs, int count)
         c_strcpy(settings.hideGlimmeringText, "0", sizeof(settings.hideGlimmeringText));
         c_strcpy(settings.mouseEnabled, "1", sizeof(settings.mouseEnabled));
 #ifdef __APPLE__
-        c_strcpy(settings.visualizerEnabled, "0", sizeof(settings.visualizerEnabled)); // visualizer looks wonky in default terminal
-        c_strcpy(settings.useConfigColors, "1", sizeof(settings.useConfigColors));     // colors from album look wrong in default terminal
+        c_strcpy(settings.visualizerEnabled, "0", sizeof(settings.visualizerEnabled)); // Visualizer looks wonky in default terminal
+        c_strcpy(settings.useConfigColors, "1", sizeof(settings.useConfigColors));     // Colors from album look wrong in default terminal
 #else
         c_strcpy(settings.visualizerEnabled, "1", sizeof(settings.visualizerEnabled));
         c_strcpy(settings.useConfigColors, "0", sizeof(settings.useConfigColors));
@@ -632,7 +632,7 @@ void getConfig(AppSettings *settings, UISettings *ui)
 
         char *filepath = getConfigFilePath(configdir);
 
-        KeyValuePair *pairs = readKeyValuePairs(filepath, &pair_count, &ui->lastTimeAppRan);
+        KeyValuePair *pairs = readKeyValuePairs(filepath, &pair_count, &(ui->lastTimeAppRan));
 
         free(filepath);
         *settings = constructAppSettings(pairs, pair_count);

--- a/src/songloader.c
+++ b/src/songloader.c
@@ -91,7 +91,7 @@ void loadMetaData(SongData *songdata, AppState *state)
 
         generateTempFilePath(songdata->coverArtPath, "cover", ".jpg");
 
-        int res = extractTags(songdata->filePath, songdata->metadata, &songdata->duration, songdata->coverArtPath);
+        int res = extractTags(songdata->filePath, songdata->metadata, &(songdata->duration), songdata->coverArtPath);
 
         if (res == -2)
         {
@@ -119,7 +119,7 @@ void loadMetaData(SongData *songdata, AppState *state)
                 addToCache(state->tempCache, songdata->coverArtPath);
         }
 
-        songdata->cover = getBitmap(songdata->coverArtPath, &songdata->coverWidth, &songdata->coverHeight);
+        songdata->cover = getBitmap(songdata->coverArtPath, &(songdata->coverWidth), &(songdata->coverHeight));
 }
 
 SongData *loadSongData(char *filePath, AppState *state)

--- a/src/sound.c
+++ b/src/sound.c
@@ -45,7 +45,7 @@ ma_result initFirstDatasource(AudioData *pAudioData, UserData *pUserData)
                 pAudioData->format = first->outputFormat;
                 pAudioData->channels = first->outputChannels;
                 pAudioData->sampleRate = first->outputSampleRate;
-                ma_data_source_get_length_in_pcm_frames(first, &pAudioData->totalFrames);
+                ma_data_source_get_length_in_pcm_frames(first, &(pAudioData->totalFrames));
         }
         else if (pathEndsWith(filePath, "opus"))
         {
@@ -54,8 +54,8 @@ ma_result initFirstDatasource(AudioData *pAudioData, UserData *pUserData)
                         return -1;
                 ma_libopus *first = getFirstOpusDecoder();
                 ma_channel channelMap[MA_MAX_CHANNELS];
-                ma_libopus_ds_get_data_format(first, &pAudioData->format, &pAudioData->channels, &pAudioData->sampleRate, channelMap, MA_MAX_CHANNELS);
-                ma_data_source_get_length_in_pcm_frames(first, &pAudioData->totalFrames);
+                ma_libopus_ds_get_data_format(first, &(pAudioData->format), &(pAudioData->channels), &(pAudioData->sampleRate), channelMap, MA_MAX_CHANNELS);
+                ma_data_source_get_length_in_pcm_frames(first, &(pAudioData->totalFrames));
                 ma_data_source_base *base = (ma_data_source_base *)first;
                 base->pCurrent = first;
                 first->pReadSeekTellUserData = pAudioData;
@@ -67,8 +67,8 @@ ma_result initFirstDatasource(AudioData *pAudioData, UserData *pUserData)
                         return -1;
                 ma_libvorbis *first = getFirstVorbisDecoder();
                 ma_channel channelMap[MA_MAX_CHANNELS];
-                ma_libvorbis_ds_get_data_format(first, &pAudioData->format, &pAudioData->channels, &pAudioData->sampleRate, channelMap, MA_MAX_CHANNELS);
-                ma_data_source_get_length_in_pcm_frames(first, &pAudioData->totalFrames);
+                ma_libvorbis_ds_get_data_format(first, &(pAudioData->format), &(pAudioData->channels), &(pAudioData->sampleRate), channelMap, MA_MAX_CHANNELS);
+                ma_data_source_get_length_in_pcm_frames(first, &(pAudioData->totalFrames));
                 ma_data_source_base *base = (ma_data_source_base *)first;
                 base->pCurrent = first;
                 first->pReadSeekTellUserData = pAudioData;
@@ -82,8 +82,8 @@ ma_result initFirstDatasource(AudioData *pAudioData, UserData *pUserData)
                         return -1;
                 m4a_decoder *first = getFirstM4aDecoder();
                 ma_channel channelMap[MA_MAX_CHANNELS];
-                m4a_decoder_ds_get_data_format(first, &pAudioData->format, &pAudioData->channels, &pAudioData->sampleRate, channelMap, MA_MAX_CHANNELS);
-                ma_data_source_get_length_in_pcm_frames(first, &pAudioData->totalFrames);
+                m4a_decoder_ds_get_data_format(first, &(pAudioData->format), &(pAudioData->channels), &(pAudioData->sampleRate), channelMap, MA_MAX_CHANNELS);
+                ma_data_source_get_length_in_pcm_frames(first, &(pAudioData->totalFrames));
                 ma_data_source_base *base = (ma_data_source_base *)first;
                 base->pCurrent = first;
                 first->pReadSeekTellUserData = pAudioData;

--- a/src/soundbuiltin.c
+++ b/src/soundbuiltin.c
@@ -96,7 +96,7 @@ ma_data_source_vtable builtin_file_data_source_vtable = {
     builtin_file_data_source_get_cursor,
     builtin_file_data_source_get_length,
     builtin_file_data_source_set_looping,
-    0 // flags
+    0 // Flags
 };
 
 double dbToLinear(double db)
@@ -165,7 +165,7 @@ void builtin_read_pcm_frames(ma_data_source *pDataSource, void *pFramesOut, ma_u
                 }
 
                 if (audioData->totalFrames == 0)
-                        ma_data_source_get_length_in_pcm_frames(decoder, &audioData->totalFrames);
+                        ma_data_source_get_length_in_pcm_frames(decoder, &(audioData->totalFrames));
 
                 if (isSeekRequested())
                 {
@@ -316,6 +316,6 @@ void builtin_on_audio_frames(ma_device *pDevice, void *pFramesOut, const void *p
 {
         AudioData *pDataSource = (AudioData *)pDevice->pUserData;
         ma_uint64 framesRead = 0;
-        builtin_read_pcm_frames(&pDataSource->base, pFramesOut, frameCount, &framesRead);
+        builtin_read_pcm_frames(&(pDataSource->base), pFramesOut, frameCount, &framesRead);
         (void)pFramesIn;
 }

--- a/src/soundcommon.c
+++ b/src/soundcommon.c
@@ -142,7 +142,7 @@ void setNextDecoder(void **decoderArray, void **decoder, void **firstDecoder, in
         {
                 *firstDecoder = *decoder;
         }
-        else if (*decoderIndex == -1) // array hasn't been used yet
+        else if (*decoderIndex == -1) // Array hasn't been used yet
         {
                 if (decoderArray[0] != NULL)
                 {
@@ -819,7 +819,7 @@ void seekPercentage(float percent)
 
 void resumePlayback(void)
 {
-        // if this was unpaused with no song loaded
+        // If this was unpaused with no song loaded
         if (audioData.restart && !isRadioPlaying())
         {
                 audioData.endOfListReached = false;
@@ -1171,7 +1171,7 @@ void m4a_read_pcm_frames(ma_data_source *pDataSource, void *pFramesOut, ma_uint6
                 m4a_decoder *decoder = getCurrentM4aDecoder();
 
                 if (pAudioData->totalFrames == 0)
-                        ma_data_source_get_length_in_pcm_frames(decoder, &pAudioData->totalFrames);
+                        ma_data_source_get_length_in_pcm_frames(decoder, &(pAudioData->totalFrames));
 
                 // Check if seeking is requested
                 if (isSeekRequested())
@@ -1260,7 +1260,7 @@ void m4a_on_audio_frames(ma_device *pDevice, void *pFramesOut, const void *pFram
 {
         AudioData *pDataSource = (AudioData *)pDevice->pUserData;
         ma_uint64 framesRead = 0;
-        m4a_read_pcm_frames(&pDataSource->base, pFramesOut, frameCount, &framesRead);
+        m4a_read_pcm_frames(&(pDataSource->base), pFramesOut, frameCount, &framesRead);
         (void)pFramesIn;
 }
 #endif
@@ -1299,7 +1299,7 @@ void opus_read_pcm_frames(ma_data_source *pDataSource, void *pFramesOut, ma_uint
                 ma_libopus *decoder = getCurrentOpusDecoder();
 
                 if (pAudioData->totalFrames == 0)
-                        ma_data_source_get_length_in_pcm_frames(decoder, &pAudioData->totalFrames);
+                        ma_data_source_get_length_in_pcm_frames(decoder, &(pAudioData->totalFrames));
 
                 // Check if seeking is requested
                 if (isSeekRequested())
@@ -1388,7 +1388,7 @@ void opus_on_audio_frames(ma_device *pDevice, void *pFramesOut, const void *pFra
 {
         AudioData *pDataSource = (AudioData *)pDevice->pUserData;
         ma_uint64 framesRead = 0;
-        opus_read_pcm_frames(&pDataSource->base, pFramesOut, frameCount, &framesRead);
+        opus_read_pcm_frames(&(pDataSource->base), pFramesOut, frameCount, &framesRead);
         (void)pFramesIn;
 }
 
@@ -1420,7 +1420,7 @@ void vorbis_read_pcm_frames(ma_data_source *pDataSource, void *pFramesOut, ma_ui
                 ma_libvorbis *decoder = getCurrentVorbisDecoder();
 
                 if (pAudioData->totalFrames == 0)
-                        ma_data_source_get_length_in_pcm_frames(decoder, &pAudioData->totalFrames);
+                        ma_data_source_get_length_in_pcm_frames(decoder, &(pAudioData->totalFrames));
 
                 if ((getCurrentImplementationType() != VORBIS && !isSkipToNext()) || (decoder == NULL))
                 {
@@ -1516,6 +1516,6 @@ void vorbis_on_audio_frames(ma_device *pDevice, void *pFramesOut, const void *pF
 {
         AudioData *pDataSource = (AudioData *)pDevice->pUserData;
         ma_uint64 framesRead = 0;
-        vorbis_read_pcm_frames(&pDataSource->base, pFramesOut, frameCount, &framesRead);
+        vorbis_read_pcm_frames(&(pDataSource->base), pFramesOut, frameCount, &framesRead);
         (void)pFramesIn;
 }

--- a/src/soundradio.c
+++ b/src/soundradio.c
@@ -659,11 +659,11 @@ static size_t curl_writefunc(void *ptr, size_t size, size_t nmemb, void *userdat
         size_t bytes = size * nmemb;
         size_t written = 0;
 
-        pthread_mutex_lock(&buf->mutex);
+        pthread_mutex_lock(&(buf->mutex));
 
         if (buf->eof)
         {
-                pthread_mutex_unlock(&buf->mutex);
+                pthread_mutex_unlock(&(buf->mutex));
                 return 0;
         }
 
@@ -686,8 +686,8 @@ static size_t curl_writefunc(void *ptr, size_t size, size_t nmemb, void *userdat
         buf->last_data_time = time(NULL);
 
         // Signal to the consumer that the data is ready
-        pthread_cond_signal(&buf->cond);
-        pthread_mutex_unlock(&buf->mutex);
+        pthread_cond_signal(&(buf->cond));
+        pthread_mutex_unlock(&(buf->mutex));
 
         return bytes;
 }
@@ -698,7 +698,7 @@ static ma_result decoder_read_callback(ma_decoder *decoder, void *pBufferOut, si
         size_t total_read = 0;
         unsigned char *out = (unsigned char *)pBufferOut;
 
-        pthread_mutex_lock(&buf->mutex);
+        pthread_mutex_lock(&(buf->mutex));
 
         while (total_read < bytesToRead)
         {
@@ -711,7 +711,7 @@ static ma_result decoder_read_callback(ma_decoder *decoder, void *pBufferOut, si
                         ts.tv_sec += WAIT_TIMEOUT_SECONDS;
 
                         // Use timed wait
-                        int wait_result = pthread_cond_timedwait(&buf->cond, &buf->mutex, &ts);
+                        int wait_result = pthread_cond_timedwait(&(buf->cond), &(buf->mutex), &ts);
                         if (wait_result == ETIMEDOUT)
                         {
                                 // Check how long it's been since last data arrived
@@ -719,7 +719,7 @@ static ma_result decoder_read_callback(ma_decoder *decoder, void *pBufferOut, si
                                 if ((now - buf->last_data_time) >= WAIT_TIMEOUT_SECONDS)
                                 {
                                         // We haven't received data in too long, so signal error.
-                                        pthread_mutex_unlock(&buf->mutex);
+                                        pthread_mutex_unlock(&(buf->mutex));
                                         *bytesRead = total_read;
 
                                         buf->stale = true;
@@ -731,7 +731,7 @@ static ma_result decoder_read_callback(ma_decoder *decoder, void *pBufferOut, si
 
                 if ((buf->read_pos == buf->write_pos) && buf->eof)
                 {
-                        pthread_mutex_unlock(&buf->mutex);
+                        pthread_mutex_unlock(&(buf->mutex));
                         *bytesRead = total_read;
                         return (total_read > 0) ? MA_SUCCESS : MA_AT_END;
                 }
@@ -744,12 +744,12 @@ static ma_result decoder_read_callback(ma_decoder *decoder, void *pBufferOut, si
                                      ? chunk
                                      : (bytesToRead - total_read);
 
-                memcpy(out + total_read, &buf->buffer[buf->read_pos], to_copy);
+                memcpy(out + total_read, &(buf->buffer[buf->read_pos]), to_copy);
                 buf->read_pos = (buf->read_pos + to_copy) % STREAM_BUFFER_SIZE;
                 total_read += to_copy;
         }
 
-        pthread_mutex_unlock(&buf->mutex);
+        pthread_mutex_unlock(&(buf->mutex));
 
         *bytesRead = total_read;
         return MA_SUCCESS;
@@ -816,12 +816,12 @@ void freeCurrentlyPlayingRadioStation(void)
 
 void stopRadio(void)
 {
-        pthread_mutex_lock(&radioContext.buf.mutex);
+        pthread_mutex_lock(&(radioContext.buf.mutex));
         radioContext.buf.eof = 1;
         radioContext.buf.read_pos = radioContext.buf.write_pos = 0;
         radioContext.buf.stale = false;
-        pthread_cond_broadcast(&radioContext.buf.cond);
-        pthread_mutex_unlock(&radioContext.buf.mutex);
+        pthread_cond_broadcast(&(radioContext.buf.cond));
+        pthread_mutex_unlock(&(radioContext.buf.mutex));
 
         if (radioContext.curl_thread)
         {
@@ -833,7 +833,7 @@ void stopRadio(void)
 
         memset(&device, 0, sizeof(device));
 
-        ma_decoder_uninit(&radioContext.decoder);
+        ma_decoder_uninit(&(radioContext.decoder));
 
         if (radioContext.curl != NULL)
         {
@@ -841,10 +841,10 @@ void stopRadio(void)
                 radioContext.curl = NULL;
         }
 
-        pthread_mutex_destroy(&radioContext.buf.mutex);
-        pthread_cond_destroy(&radioContext.buf.cond);
+        pthread_mutex_destroy(&(radioContext.buf.mutex));
+        pthread_cond_destroy(&(radioContext.buf.cond));
 
-        memset(&radioContext.decoder, 0, sizeof(ma_decoder));
+        memset(&(radioContext.decoder), 0, sizeof(ma_decoder));
 
         radioIsPlaying = false;
 
@@ -901,27 +901,27 @@ int playRadioStation(const RadioSearchResult *station)
                 return -1;
         }
 
-        pthread_mutex_init(&radioContext.buf.mutex, NULL);
-        pthread_cond_init(&radioContext.buf.cond, NULL);
+        pthread_mutex_init(&(radioContext.buf.mutex), NULL);
+        pthread_cond_init(&(radioContext.buf.cond), NULL);
         radioContext.buf.eof = 0;
         radioContext.buf.stale = false;
 
         curl_easy_setopt(radioContext.curl, CURLOPT_URL, station->url_resolved);
         curl_easy_setopt(radioContext.curl, CURLOPT_WRITEFUNCTION, curl_writefunc);
-        curl_easy_setopt(radioContext.curl, CURLOPT_WRITEDATA, &radioContext.buf);
+        curl_easy_setopt(radioContext.curl, CURLOPT_WRITEDATA, &(radioContext.buf));
         curl_easy_setopt(radioContext.curl, CURLOPT_FOLLOWLOCATION, 1L);
 
         char userAgent[64];
         snprintf(userAgent, sizeof(userAgent), "kew/%s", VERSION);
         curl_easy_setopt(radioContext.curl, CURLOPT_USERAGENT, userAgent);
 
-        pthread_create(&radioContext.curl_thread, NULL, curl_perform_wrapper, radioContext.curl);
+        pthread_create(&(radioContext.curl_thread), NULL, curl_perform_wrapper, radioContext.curl);
 
         ma_decoder_config decoderConfig = ma_decoder_config_init(ma_format_f32, 2, 44100);
 
         decoderConfig.encodingFormat = ma_encoding_format_mp3;
 
-        if (ma_decoder_init(decoder_read_callback, decoder_seek_callback, &radioContext.buf, &decoderConfig, &radioContext.decoder) != MA_SUCCESS)
+        if (ma_decoder_init(decoder_read_callback, decoder_seek_callback, &(radioContext.buf), &decoderConfig, &(radioContext.decoder)) != MA_SUCCESS)
         {
                 fprintf(stderr, "Decoder init failed\n");
                 setErrorMessage("Radio station unsupported or unavailable.");
@@ -934,12 +934,12 @@ int playRadioStation(const RadioSearchResult *station)
         devConfig.playback.channels = radioContext.decoder.outputChannels;
         devConfig.sampleRate = radioContext.decoder.outputSampleRate;
         devConfig.dataCallback = audio_data_callback;
-        devConfig.pUserData = &radioContext.decoder;
+        devConfig.pUserData = &(radioContext.decoder);
 
         if (ma_device_init(NULL, &devConfig, &device) != MA_SUCCESS)
         {
                 fprintf(stderr, "Device init failed\n");
-                ma_decoder_uninit(&radioContext.decoder);
+                ma_decoder_uninit(&(radioContext.decoder));
                 return -1;
         }
 
@@ -949,7 +949,7 @@ int playRadioStation(const RadioSearchResult *station)
         {
                 fprintf(stderr, "Failed to start device playback\n");
                 ma_device_uninit(&device);
-                ma_decoder_uninit(&radioContext.decoder);
+                ma_decoder_uninit(&(radioContext.decoder));
                 return -1;
         }
 
@@ -958,7 +958,7 @@ int playRadioStation(const RadioSearchResult *station)
 
         refresh = true;
 
-        pthread_cond_signal(&radioContext.buf.cond);
+        pthread_cond_signal(&(radioContext.buf.cond));
 
         radioIsPlaying = true;
 

--- a/src/tagLibWrapper.cpp
+++ b/src/tagLibWrapper.cpp
@@ -323,7 +323,7 @@ extern "C"
                                         // Clean up stream states
                                         for (auto &streamEntry : streams)
                                         {
-                                                ogg_stream_clear(&streamEntry.second);
+                                                ogg_stream_clear(&(streamEntry.second));
                                         }
                                         return false; // Could not write to output file
                                 }
@@ -338,7 +338,7 @@ extern "C"
                 // Clean up stream states
                 for (auto &streamEntry : streams)
                 {
-                        ogg_stream_clear(&streamEntry.second);
+                        ogg_stream_clear(&(streamEntry.second));
                 }
 
                 // Return whether the cover art was successfully found and written


### PR DESCRIPTION
This PR uses the preferred syntax for dereferencing an item in a struct, with brackets included. For example, `&(appState->uiSettings)` instead of `&appState->uiSettings`. This PR also capitalizes comments that needed to be capitalized.