### PR TITLE
Clean up title before printing

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -197,17 +197,26 @@ int printLogo(SongData *songData, UISettings *ui)
 
                 char title[MAXPATHLEN] = {0};
 
+                int titleLength = strnlen(songData->metadata->title, METADATA_MAX_SIZE);
+                char prettyTitle[titleLength + 1];
+
+                strncpy(prettyTitle, songData->metadata->title, titleLength);
+                prettyTitle[titleLength] = '\0';
+
+                removeUnneededChars(prettyTitle, titleLength);
+                trim(prettyTitle, titleLength);
+
                 if (ui->hideLogo && songData->metadata->artist[0] != '\0')
                 {
                         printBlankSpaces(indent);
                         snprintf(title, MAXPATHLEN, "%s - %s",
-                                 songData->metadata->artist, songData->metadata->title);
+                                 songData->metadata->artist, prettyTitle);
                 }
                 else
                 {
                         if (ui->hideLogo)
                                 printBlankSpaces(indent);
-                        c_strcpy(title, songData->metadata->title, METADATA_MAX_SIZE - 1);
+                        c_strcpy(title, prettyTitle, METADATA_MAX_SIZE - 1);
                         title[MAXPATHLEN - 1] = '\0';
                 }
 
@@ -384,7 +393,17 @@ void printBasicMetadata(TagSettings const *metadata, UISettings *ui)
                         printf("\033[1;38;2;%03u;%03u;%03um", pixel.r, pixel.g, pixel.b);
                 }
 
-                printTitleWithDelay(metadata->title, ui->titleDelay, maxWidth);
+                // Clean up title before printing
+                int titleLength = strnlen(metadata->title, maxWidth);
+                char prettyTitle[titleLength + 1];
+
+                strncpy(prettyTitle, metadata->title, titleLength);
+                prettyTitle[titleLength] = '\0';
+
+                removeUnneededChars(prettyTitle, titleLength);
+                trim(prettyTitle, titleLength);
+
+                printTitleWithDelay(prettyTitle, ui->titleDelay, maxWidth);
         }
         else
         {

--- a/src/utils.c
+++ b/src/utils.c
@@ -325,22 +325,20 @@ char *getFilePath(const char *filename)
 void removeUnneededChars(char *str, int length)
 {
         // Do not remove characters if filename only contains digits
-        int i = 0;
         bool stringContainsLetters = false;
-        while (str[i] != '\0')
+        for (int i = 0; str[i] != '\0'; i++)
         {
                 if (!isdigit(str[i]))
                 {
                         stringContainsLetters = true;
                 }
-                i++;
         }
         if (!stringContainsLetters)
         {
                 return;
         }
 
-        for (i = 0; i < 3 && str[i] != '\0' && str[i] != ' '; i++)
+        for (int i = 0; i < 3 && str[i] != '\0' && str[i] != ' '; i++)
         {
                 if (isdigit(str[i]) || str[i] == '.' || str[i] == '-' || str[i] == ' ')
                 {
@@ -356,15 +354,13 @@ void removeUnneededChars(char *str, int length)
         }
 
         // Remove hyphens and underscores from filename
-        i = 0;
-        while (str[i] != '\0')
+        for (int i = 0; str[i] != '\0'; i++)
         {
                 // Only remove if there are no spaces around
                 if ((str[i] == '-' || str[i] == '_') && (i > 0 && i < length && str[i - 1] != ' ' && str[i + 1] != ' '))
                 {
                         str[i] = ' ';
                 }
-                i++;
         }
 }
 


### PR DESCRIPTION
This PR cleans up the track title before printing in track view or next to the logo in other views. Now the title in those places would look exactly like in the directory tree.

This PR also clean up `removeUnneededChars`.