### PR TITLE
Fix broken alt + mouse action

### DIFF
--- a/src/kew.c
+++ b/src/kew.c
@@ -1756,6 +1756,13 @@ void initState(AppState *state)
         state->uiSettings.cacheLibrary = -1;
         state->uiSettings.useConfigColors = false;
         state->uiSettings.mouseEnabled = true;
+        state->uiSettings.mouseLeftClickAction = 0;
+        state->uiSettings.mouseMiddleClickAction = 1;
+        state->uiSettings.mouseRightClickAction = 2;
+        state->uiSettings.mouseScrollUpAction = 3;
+        state->uiSettings.mouseScrollDownAction = 4;
+        state->uiSettings.mouseAltScrollUpAction = 7;
+        state->uiSettings.mouseAltScrollDownAction = 8;
         state->uiSettings.progressBarType = 0;
         state->uiState.numDirectoryTreeEntries = 0;
         state->uiState.numProgressBars = 35;

--- a/src/settings.c
+++ b/src/settings.c
@@ -300,11 +300,11 @@ AppSettings constructAppSettings(KeyValuePair *pairs, int count)
                 {
                         snprintf(settings.mouseScrollDownAction, sizeof(settings.mouseScrollDownAction), "%s", pair->value);
                 }
-                else if (strcmp(lowercaseKey, "mouseshiftscrollupaction") == 0)
+                else if (strcmp(lowercaseKey, "mousealtscrollupaction") == 0)
                 {
                         snprintf(settings.mouseAltScrollUpAction, sizeof(settings.mouseAltScrollUpAction), "%s", pair->value);
                 }
-                else if (strcmp(lowercaseKey, "mouseshiftscrolldownaction") == 0)
+                else if (strcmp(lowercaseKey, "mousealtscrolldownaction") == 0)
                 {
                         snprintf(settings.mouseAltScrollDownAction, sizeof(settings.mouseAltScrollDownAction), "%s", pair->value);
                 }


### PR DESCRIPTION
It was broken because it was reading the config option wrong. It was reading the option as `mouseshiftscrollupaction` instead of `mousealtscrollupaction`, a mistake on my end from implementing it at https://github.com/ravachol/kew/commit/3099200fb64490f1b4be856dfeb9478e5c4cf29c. It didn't default to its default value because there were no defaults set in `initState`.