### PR TITLE
Add options to change progress bar characters in config

### DIFF
--- a/src/appstate.h
+++ b/src/appstate.h
@@ -66,7 +66,6 @@ typedef struct
         time_t lastTimeAppRan;                          // When did this app run last, used for updating the cached library if it has been modified since that time
         float tweenFactor;                              // How fast the bars in the visualizer rise (higher value = faster)
         float tweenFactorFall;                          // How fast the bars in the visualizer fall (higher value = faster)
-        int progressBarType;                  // What method for showing the progress in track view. Default 0.
 } UISettings;
 
 typedef struct
@@ -210,7 +209,12 @@ typedef struct
         char visualizerBrailleMode[2];
         char tweenFactor[12];
         char tweenFactorFall[12];
-        char progressBarType[2];
+        char progressBarElapsedEvenChar[12];
+        char progressBarElapsedOddChar[12];
+        char progressBarApproachingEvenChar[12];
+        char progressBarApproachingOddChar[12];
+        char progressBarCurrentEvenChar[12];
+        char progressBarCurrentOddChar[12];
 } AppSettings;
 
 #endif

--- a/src/kew.c
+++ b/src/kew.c
@@ -1775,7 +1775,6 @@ void initState(AppState *state)
         state->uiSettings.mouseScrollDownAction = 4;
         state->uiSettings.mouseAltScrollUpAction = 7;
         state->uiSettings.mouseAltScrollDownAction = 8;
-        state->uiSettings.progressBarType = 0;
         state->uiState.numDirectoryTreeEntries = 0;
         state->uiState.numProgressBars = 35;
         state->uiState.chosenNodeId = 0;


### PR DESCRIPTION
Adds these options to the config file:

```
progressBarElapsedEvenChar
progressBarElapsedOddChar
progressBarApproachingEvenChar
progressBarApproachingOddChar
progressBarCurrentEvenChar
progressBarCurrentOddChar
```

Has multibyte character support for more customization.

When more than 1 character is given in the config, it will take the first character, multibyte or not.

When nothing is given in the config, it will default to the thick line.

The thick line remains as the default.

Removes `progressBarType` as it is not needed anymore.

Related to https://github.com/ravachol/kew/pull/332