### PR TITLE
Clean up directory names in playlist view before displaying

### DIFF
--- a/src/player_ui.c
+++ b/src/player_ui.c
@@ -1450,6 +1450,8 @@ int displayTree(FileSystemEntry *root, int depth, int maxListSize, int maxNameWi
                                                 snprintf(dirName, maxNameWidth + 1 - extraIndent, "%s", "─ MUSIC LIBRARY ─");
                                         else
                                                 snprintf(dirName, maxNameWidth + 1 - extraIndent, "%s", root->name);
+                                                removeUnneededChars(dirName, maxNameWidth - 1);
+                                                trim(dirName, maxNameWidth - 1);
 
                                         char *upperDirName = stringToUpper(dirName);
 


### PR DESCRIPTION
Some of my album directory names are numbered, and I think it would be better if their names were cleaned up, like the track filenames.