### PR TITLE
Add option to set window title to track title

### DIFF
--- a/src/appstate.h
+++ b/src/appstate.h
@@ -68,6 +68,7 @@ typedef struct
         bool saveRepeatShuffleSettings;                 // Save repeat and shuffle settings between sessions. Default on.
         int repeatState;                                // 0=disabled,1=repeat track ,2=repeat list
         bool shuffleEnabled;
+        bool trackTitleAsWindowTitle;                   // Set the window title to the title of the currently playing track
 } UISettings;
 
 typedef struct
@@ -216,6 +217,7 @@ typedef struct
         char saveRepeatShuffleSettings[2];
         char repeatState[2];
         char shuffleEnabled[2];
+        char trackTitleAsWindowTitle[2];
 } AppSettings;
 
 #endif

--- a/src/kew.c
+++ b/src/kew.c
@@ -1729,9 +1729,13 @@ void setMusicPath()
 void enableMouse(UISettings *ui)
 {
         if (ui->mouseEnabled)
-        {
                 enableTerminalMouseButtons();
-        }
+}
+
+void setTrackTitleAsWindowTitle(UISettings *ui)
+{
+        if (ui->trackTitleAsWindowTitle)
+                setTerminalWindowTitle("kew");
 }
 
 void initState(AppState *state)
@@ -1766,6 +1770,7 @@ void initState(AppState *state)
         state->uiSettings.saveRepeatShuffleSettings = 1;
         state->uiSettings.repeatState = 0;
         state->uiSettings.shuffleEnabled = 0;
+        state->uiSettings.trackTitleAsWindowTitle = 1;
         state->uiState.numDirectoryTreeEntries = 0;
         state->uiState.numProgressBars = 35;
         state->uiState.chosenNodeId = 0;
@@ -1787,6 +1792,7 @@ void initializeStateAndSettings(AppState *appState, AppSettings *settings)
         userData.replayGainCheckFirst = appState->uiSettings.replayGainCheckFirst;
         mapSettingsToKeys(settings, &(appState->uiSettings), keyMappings);
         enableMouse(&(appState->uiSettings));
+        setTrackTitleAsWindowTitle(&(appState->uiSettings));
 }
 
 int main(int argc, char *argv[])

--- a/src/player_ui.c
+++ b/src/player_ui.c
@@ -1705,6 +1705,9 @@ int printPlayer(SongData *songdata, double elapsedSeconds, AppSettings *settings
                         ui->color.r = songdata->red;
                         ui->color.g = songdata->green;
                         ui->color.b = songdata->blue;
+
+                        if (ui->trackTitleAsWindowTitle)
+                                setTerminalWindowTitle(songdata->metadata->title);
                 }
                 else
                 {
@@ -1716,6 +1719,9 @@ int printPlayer(SongData *songdata, double elapsedSeconds, AppSettings *settings
                         ui->color.r = defaultColor;
                         ui->color.g = defaultColor;
                         ui->color.b = defaultColor;
+
+                        if (ui->trackTitleAsWindowTitle)
+                                setTerminalWindowTitle("kew");
                 }
 
                 calcPreferredSize(ui);

--- a/src/settings.c
+++ b/src/settings.c
@@ -62,6 +62,7 @@ AppSettings constructAppSettings(KeyValuePair *pairs, int count)
         c_strcpy(settings.progressBarCurrentEvenChar, "━", sizeof(settings.progressBarCurrentEvenChar));
         c_strcpy(settings.progressBarCurrentOddChar, "━", sizeof(settings.progressBarCurrentOddChar));
         c_strcpy(settings.saveRepeatShuffleSettings, "1", sizeof(settings.saveRepeatShuffleSettings));
+        c_strcpy(settings.trackTitleAsWindowTitle, "1", sizeof(settings.trackTitleAsWindowTitle));
 #ifdef __APPLE__
         // Visualizer looks wonky in default terminal but let's enable it anyway. People need to switch
         c_strcpy(settings.visualizerEnabled, "1", sizeof(settings.visualizerEnabled));
@@ -310,6 +311,10 @@ AppSettings constructAppSettings(KeyValuePair *pairs, int count)
                 else if (strcmp(lowercaseKey, "saverepeatshufflesettings") == 0)
                 {
                         snprintf(settings.saveRepeatShuffleSettings, sizeof(settings.saveRepeatShuffleSettings), "%s", pair->value);
+                }
+                else if (strcmp(lowercaseKey, "tracktitleaswindowtitle") == 0)
+                {
+                        snprintf(settings.trackTitleAsWindowTitle, sizeof(settings.trackTitleAsWindowTitle), "%s", pair->value);
                 }
                 else if (strcmp(lowercaseKey, "replaygaincheckfirst") == 0)
                 {
@@ -830,6 +835,7 @@ void getConfig(AppSettings *settings, UISettings *ui)
         ui->hideLogo = (settings->hideLogo[0] == '1');
         ui->hideHelp = (settings->hideHelp[0] == '1');
         ui->saveRepeatShuffleSettings = (settings->saveRepeatShuffleSettings[0] == '1');
+        ui->trackTitleAsWindowTitle = (settings->trackTitleAsWindowTitle[0] == '1');
 
         int tmp = getNumber(settings->color);
         if (tmp >= 0)
@@ -953,6 +959,8 @@ void setConfig(AppSettings *settings, UISettings *ui)
                 ui->hideGlimmeringText ? c_strcpy(settings->hideGlimmeringText, "1", sizeof(settings->hideGlimmeringText)) : c_strcpy(settings->hideGlimmeringText, "0", sizeof(settings->hideGlimmeringText));
         if (settings->mouseEnabled[0] == '\0')
                 ui->mouseEnabled ? c_strcpy(settings->mouseEnabled, "1", sizeof(settings->mouseEnabled)) : c_strcpy(settings->mouseEnabled, "0", sizeof(settings->mouseEnabled));
+        if (settings->trackTitleAsWindowTitle[0] == '\0')
+                ui->trackTitleAsWindowTitle ? c_strcpy(settings->trackTitleAsWindowTitle, "1", sizeof(settings->trackTitleAsWindowTitle)) : c_strcpy(settings->trackTitleAsWindowTitle, "0", sizeof(settings->trackTitleAsWindowTitle));
 
         snprintf(settings->repeatState, sizeof(settings->repeatState), "%d", ui->repeatState);
 
@@ -1040,6 +1048,9 @@ void setConfig(AppSettings *settings, UISettings *ui)
 
         fprintf(file, "repeatState=%s\n\n", settings->repeatState);
         fprintf(file, "shuffleEnabled=%s\n\n", settings->shuffleEnabled);
+
+        fprintf(file, "# Set the window title to the title of the currently playing track\n");
+        fprintf(file, "trackTitleAsWindowTitle=%s\n\n", settings->trackTitleAsWindowTitle);
 
         fprintf(file, "\n[visualizer]\n\n");
         fprintf(file, "visualizerEnabled=%s\n", settings->visualizerEnabled);

--- a/src/term.c
+++ b/src/term.c
@@ -256,3 +256,9 @@ void disableTerminalMouseButtons()
         // Disable program to accept mouse input as codes
         printf("\033[?1002l\033[?1006l");
 }
+
+void setTerminalWindowTitle(char *title)
+{
+        // Only change window title, no icon
+        printf("\033]2;%s\007", title);
+}

--- a/src/term.h
+++ b/src/term.h
@@ -62,4 +62,6 @@ void enableTerminalMouseButtons(void);
 
 void disableTerminalMouseButtons(void);
 
+void setTerminalWindowTitle(char *title);
+
 #endif


### PR DESCRIPTION
When a track is played, the window title will be set to the title of the track that was played. If no track is currently playing, the window title defaults to "kew". This behavior can be toggled with the `trackTitleAsWindowTitle` option in the config file.

Closes https://github.com/ravachol/kew/issues/366.