### PR TITLE
Make the `printLastRow`(footer) display the correct alt shortcut on macos

### DIFF
--- a/src/player_ui.c
+++ b/src/player_ui.c
@@ -626,7 +626,7 @@ void printLastRow(int row, int col, UISettings *ui, AppSettings *settings)
         formatWithShiftPlus(search, sizeof(search), settings->showSearchAlt);
         formatWithShiftPlus(help, sizeof(help), settings->showKeysAlt);
 
-        snprintf(text, sizeof(text), "%s: Playlist|%s: Library|%s: Track|%s: Search|%s: Help",
+        snprintf(text, sizeof(text), "%s Playlist|%s Library|%s Track|%s Search|%s Help",
                 playlist, library, track, search, help);
 
 #else


### PR DESCRIPTION
I had several issues, that I fixed here. First, the footer (function to print it out is called `printLastRow`). I fixed this by passing the `AppSettings` for every function call and then print it. Also I made, that it only shows "Shift+" if the letter in the kewrc is actually uppercase. And lastly I changed, that instead of "Sh+" it says "Shift+". This required to make the `ABSOLUTE_MIN_WIDTH` to 80 because else it would've get cut off.
I did the last change because when I first started using kew, I was so confused on why it told me "Sh+..." was the keybinding because I never saw another program using "Sh" instead of "Shift".