### PR TITLE
Clearing out Error Message after update library task finishes

### DIFF
--- a/src/playerops.c
+++ b/src/playerops.c
@@ -2004,11 +2004,9 @@ void *updateLibraryThread(void *arg)
 
         pthread_mutex_unlock(&switchMutex);
 
+        c_sleep(1000); // Don't refresh immediately or we risk the error message not clearing
         refresh = true;
-
-        // Keep the message on screen for a second, confirmation for the user
-        sleep(1);
-        setErrorMessage("");
+        
         return NULL;
 }
 


### PR DESCRIPTION
When the user updates their library index with `u`, the error message (or status message) `Updating Library...` never clears on its own, unless switching to a different screen. This change keep it on screen for a second and clears out the message afterwards