### PR TITLE
Cleanup mouseInputHandled

### DIFF
--- a/src/kew.c
+++ b/src/kew.c
@@ -154,13 +154,13 @@ enum EventType getMouseLastRowEvent(int mouseXOnLastRow)
 
 bool mouseInputHandled(char *seq, int i, struct Event *event)
 {
-        int term_w, term_h;
-        getTermSize(&term_w, &term_h);
-        (void)term_w;
+        char tmpSeq[MAX_SEQ_LEN];
+
+        c_strcpy(tmpSeq, seq, MAX_SEQ_LEN - 1);
 
         int mouseButton, mouseX, mouseY;
         mouseButton = mouseX = mouseY = 0;
-        char *mouseTmp = strtok(seq + 3, ";");
+        char *mouseTmp = strtok(tmpSeq + 3, ";");
 
         if (mouseTmp != NULL)
                 mouseButton = getNumber(mouseTmp);
@@ -170,8 +170,6 @@ bool mouseInputHandled(char *seq, int i, struct Event *event)
         mouseTmp = strtok(NULL, ";");
         if (mouseTmp != NULL)
                 mouseY = getNumber(mouseTmp);
-
-        int indent = getIndent();
 
         if (progressBarLength > 0)
         {
@@ -183,7 +181,7 @@ bool mouseInputHandled(char *seq, int i, struct Event *event)
         }
 
         // Clicked on last row
-        if (mouseY == lastRowRow && indent > 0 &&
+        if (mouseY == lastRowRow &&
             mouseX - lastRowCol > 0 && mouseX - lastRowCol < (int)strlen(LAST_ROW) &&
             mouseButton != MOUSE_DRAG)
         {


### PR DESCRIPTION
Removes unused variables and copies seq to a temporary variable, since strtok modifies the strings it works on.