### PR TITLE
feat add option to open current song's folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ kew path "/home/joe/Musik/" (changes the path)
 * <kbd>x</kbd> to save the currently loaded playlist to a m3u file in your music folder.
 * <kbd>Tab</kbd> to switch to next view.
 * <kbd>Shift+Tab</kbd> to switch to previous view.
-
+* <kbd>e</kbd> to open the current song's folder in your file manager.
 * <kbd>f</kbd>, <kbd>g</kbd> to move songs up or down the playlist.
 * number + <kbd>G</kbd> or <kbd>Enter</kbd> to go to specific song number in the playlist.
 * <kbd>.</kbd> to add currently playing song to kew favorites.m3u (run with "kew .").

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -131,6 +131,7 @@ kew path "/home/joe/Musik/"    更改音乐库路径
 * <kbd>x</kbd> 将当前播放列表保存为 .m3u 文件
 * <kbd>Tab</kbd> 切换至下一个视图
 * <kbd>Shift+Tab</kbd> 切换至上一个视图
+* <kbd>e</kbd> 在文件管理器中打开当前歌曲所在文件夹
 * <kbd>f</kbd>、<kbd>g</kbd> 移动歌曲在播放列表中的位置
 * 数字 + <kbd>G</kbd> 或 <kbd>Enter</kbd> 跳转至指定歌曲编号
 * <kbd>.</kbd> 将当前播放歌曲添加至 kew favorites.m3u（运行 `kew .`）

--- a/docs/kew.1
+++ b/docs/kew.1
@@ -187,6 +187,9 @@ Remove a single playlist entry.
 f,g
 Move a song up or down the playlist.
 .TP 9n
+e
+Open the current song's folder in your file manager.
+.TP 9n
 number + G or Enter
 Go to specific song number in the playlist.
 .TP 9n

--- a/src/common/events.h
+++ b/src/common/events.h
@@ -49,7 +49,8 @@ enum EventType {
         EVENT_SORTLIBRARY,
         EVENT_CYCLETHEMES,
         EVENT_TOGGLENOTIFICATIONS,
-        EVENT_SHOWLYRICSPAGE
+        EVENT_SHOWLYRICSPAGE,
+        EVENT_OPENFOLDER
 };
 
 struct Event {

--- a/src/ops/library_ops.h
+++ b/src/ops/library_ops.h
@@ -17,6 +17,7 @@ void update_library(char *path);
 void ask_if_cache_library(void);
 void sort_library(void);
 void reset_sort_library(void);
+void highlight_current_song_in_folder(void);
 void mark_list_as_enqueued(FileSystemEntry *root, PlayList *playlist);
 void enqueue_song(FileSystemEntry *child);
 void dequeue_song(FileSystemEntry *child);

--- a/src/ui/input.c
+++ b/src/ui/input.c
@@ -337,6 +337,9 @@ void handle_event(struct Event *event)
         case EVENT_SORTLIBRARY:
                 sort_library();
                 break;
+        case EVENT_OPENFOLDER:
+                highlight_current_song_in_folder();
+                break;
 
         default:
                 state->uiState.isFastForwarding = false;

--- a/src/ui/player_ui.c
+++ b/src/ui/player_ui.c
@@ -1047,8 +1047,19 @@ int show_key_bindings(SongData *songdata)
         num_printed_rows++;
         CHECK_LIST_LIMIT();
         print_blank_spaces(indent);
-        printf(_(" · Add Song To 'kew favorites.m3u': %s (run with 'kew .')\n\n"),
+        printf(_(" · Add Song To 'kew favorites.m3u': %s (run with 'kew .')\n"),
                get_binding_string(EVENT_ADDTOFAVORITESPLAYLIST, false));
+        num_printed_rows++;
+        CHECK_LIST_LIMIT();
+        print_blank_spaces(indent);
+        printf(_(" · Open Current Song's Folder: %s\n"),
+               get_binding_string(EVENT_OPENFOLDER, false));
+        num_printed_rows++;
+        CHECK_LIST_LIMIT();
+        print_blank_spaces(indent);
+        printf(_(" · Move Songs in Playlist: %s and %s\n"),
+               get_binding_string(EVENT_MOVESONGUP, false),
+               get_binding_string(EVENT_MOVESONGDOWN, false));
         num_printed_rows += 2;
         CHECK_LIST_LIMIT();
         apply_color(ui->colorMode, ui->theme.text, ui->defaultColorRGB);

--- a/src/ui/settings.c
+++ b/src/ui/settings.c
@@ -89,6 +89,7 @@ TBKeyBinding key_bindings[MAX_KEY_BINDINGS] = {
     {0, 'u', 0, EVENT_UPDATELIBRARY, ""},
     {0, 'f', 0, EVENT_MOVESONGUP, ""},
     {0, 'g', 0, EVENT_MOVESONGDOWN, ""},
+    {0, 'e', 0, EVENT_OPENFOLDER, ""},
 
     {TB_KEY_ENTER, 0, 0, EVENT_ENQUEUE, ""},
     {0, 'G', 0, EVENT_ENQUEUE, ""},
@@ -466,6 +467,7 @@ static const EventMap event_map[] = {
     {"cycleThemes", EVENT_CYCLETHEMES},
     {"toggleNotifications", EVENT_TOGGLENOTIFICATIONS},
     {"showLyricsPage", EVENT_SHOWLYRICSPAGE},
+    {"openFolder", EVENT_OPENFOLDER},
     {NULL, EVENT_NONE} // Sentinel
 };
 


### PR DESCRIPTION
TLDR: I added a feature to open the current playing song in a file explorer

---

Hey there, not sure if it will be an appreciated change (I know better than anyone else that every added line to a project eventually becomes a liability), but since I already implemented it for myself, thought why not give it a shot to get it merged in!

I sometimes download tons of music, and had some annoyances that I couldn't immediately find the song wherever it was located, (multiple albums from the same artist, songs with non english names (non native to my keyboard), ...), with this I can open the song immediately in the folder, and it's highlighted to immediately perform actions on.

I decided to use `e` for the keybind, for `explorer`, since `f` and `o` were already taken by other commands.

Let me know if you have any feedback or want me to modify the implementation, I also don't mind it if you would change my implementation, I am not the most familiar with `c-lang` but tried to do my best :pray: .


Kind regards,

Reeveng