### PR TITLE
Fix switching view via mouse leads to wrong view or no view is changed

### DIFF
--- a/src/ui/player_ui.c
+++ b/src/ui/player_ui.c
@@ -889,17 +889,7 @@ void print_footer(int row, int col)
         }
 
         char text[100];
-        char playlist[32], library[32], track[32], search[32], help[32];
-
-        snprintf(playlist, sizeof(playlist), "%s", get_binding_string(EVENT_SHOWPLAYLIST, true));
-        snprintf(library, sizeof(library), "%s", get_binding_string(EVENT_SHOWLIBRARY, true));
-        snprintf(track, sizeof(track), "%s", get_binding_string(EVENT_SHOWTRACK, true));
-        snprintf(search, sizeof(search), "%s", get_binding_string(EVENT_SHOWSEARCH, true));
-        snprintf(help, sizeof(search), "%s", get_binding_string(EVENT_SHOWHELP, true));
-
-        snprintf(text, sizeof(text),
-                 _("%s Playlist|%s Library|%s Track|%s Search|%s Help"), playlist,
-                 library, track, search, help);
+        get_footer_text(text, sizeof(text));
 
         char icons_text[100] = "";
 
@@ -2684,4 +2674,19 @@ void refresh_player()
         }
 
         pthread_mutex_unlock(&(state->switch_mutex));
+}
+
+int get_footer_text(char *restrict text, size_t size)
+{
+        char playlist[32], library[32], track[32], search[32], help[32];
+
+        snprintf(playlist, sizeof(playlist), "%s", get_binding_string(EVENT_SHOWPLAYLIST, true));
+        snprintf(library, sizeof(library), "%s", get_binding_string(EVENT_SHOWLIBRARY, true));
+        snprintf(track, sizeof(track), "%s", get_binding_string(EVENT_SHOWTRACK, true));
+        snprintf(search, sizeof(search), "%s", get_binding_string(EVENT_SHOWSEARCH, true));
+        snprintf(help, sizeof(search), "%s", get_binding_string(EVENT_SHOWHELP, true));
+
+        return snprintf(text, size,
+                        _("%s Playlist|%s Library|%s Track|%s Search|%s Help"), playlist,
+                        library, track, search, help);
 }

--- a/src/ui/player_ui.h
+++ b/src/ui/player_ui.h
@@ -47,5 +47,6 @@ bool init_theme(int argc, char *argv[]);
 FileSystemEntry *get_chosen_dir(void);
 void request_next_visualization(void);
 void request_stop_visualization(void);
+int get_footer_text(char *restrict text, size_t size);
 
 #endif


### PR DESCRIPTION
When clicking the footer it takes you to the wrong view or doesn't change the view, 
because position calculation is not done with the actual printed footer text. 