### PR TITLE
Correct spelling of 'Shft' to 'Shift' in settings

### DIFF
--- a/src/ui/settings.c
+++ b/src/ui/settings.c
@@ -259,7 +259,7 @@ const char *get_modifier_string(uint8_t mods)
         if (mods & TB_MOD_SHIFT) {
                 if (!first)
                         strcat(buf, "+");
-                strcat(buf, "Shft");
+                strcat(buf, "Shift");
         }
 
         return buf;


### PR DESCRIPTION
Just a minor spelling fix