### PR TITLE
Fixed set_full_path() + changed installFlags to makeFlags in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,28 +21,28 @@
         in
         with nixpkgs.lib;
         {
-          default = pkgs.stdenv.mkDerivation (finalAttrs: 
+          default = pkgs.stdenv.mkDerivation (finalAttrs:
             let
-              uppercaseFirst = x: 
+              uppercaseFirst = x:
                 (toUpper (substring 0 1 x)) + (substring 1 ((strings.stringLength x) - 1) x);
             in
             {
               pname = "kew";
               version = kew-src.shortRev or "dev";
               src = kew-src;
-              
+
               postPatch = ''
                 substituteInPlace Makefile \
                   --replace-fail '$(shell uname -s)' '${uppercaseFirst pkgs.stdenv.hostPlatform.parsed.kernel.name}' \
                   --replace-fail '$(shell uname -m)' '${pkgs.stdenv.hostPlatform.parsed.cpu.name}'
               '';
-              
+
               nativeBuildInputs = with pkgs; [
                 pkg-config
               ] ++ optionals pkgs.stdenv.hostPlatform.isLinux [
                 autoPatchelfHook
               ];
-              
+
               buildInputs = with pkgs; [
                 fftwFloat.dev
                 chafa
@@ -56,23 +56,23 @@
                 faad2
                 libogg
               ];
-              
+
               runtimeDependencies = with pkgs; [
                 libpulseaudio
                 alsa-lib
               ];
-              
+
               enableParallelBuilding = true;
-              
-              installFlags = [
+
+              makeFlags = [
                 "MAN_DIR=${placeholder "out"}/share/man"
                 "PREFIX=${placeholder "out"}"
               ];
-              
+
               nativeInstallCheckInputs = [ pkgs.versionCheckHook ];
               versionCheckProgramArg = "--version";
               doInstallCheck = false;
-              
+
               meta = {
                 description = ''
                   Command-line music player for Linux

--- a/src/data/directorytree.c
+++ b/src/data/directorytree.c
@@ -331,7 +331,7 @@ void set_full_path(FileSystemEntry *entry,
         if (nameLen == 0) {
 
                 snprintf(entry->full_path,
-                         KEW_PATH_MAX,
+                         needed,
                          "%s",
                          parent_path);
 


### PR DESCRIPTION
Running on nixOS resulted in `zsh: abort (core dumped)  ./kew` (when creating config).
In gdb:
Thread 1 "kew" received signal SIGABRT, Aborted.
0x00007ffff6c9fdcc in __pthread_kill_implementation ()
   from /nix/store/ias8xacs1h3jy7xgwi2awvim61k2ji6c-glibc-2.42-67/lib/libc.so.6
(gdb) bt
#0  0x00007ffff6c9fdcc in __pthread_kill_implementation ()
   from /nix/store/ias8xacs1h3jy7xgwi2awvim61k2ji6c-glibc-2.42-67/lib/libc.so.6
#1  0x00007ffff6c4265e in raise ()
   from /nix/store/ias8xacs1h3jy7xgwi2awvim61k2ji6c-glibc-2.42-67/lib/libc.so.6
#2  0x00007ffff6c29350 in abort ()
   from /nix/store/ias8xacs1h3jy7xgwi2awvim61k2ji6c-glibc-2.42-67/lib/libc.so.6
#3  0x00007ffff6c2a3c8 in __libc_message_impl.cold ()
   from /nix/store/ias8xacs1h3jy7xgwi2awvim61k2ji6c-glibc-2.42-67/lib/libc.so.6
#4  0x00007ffff6d31b79 in __fortify_fail ()
   from /nix/store/ias8xacs1h3jy7xgwi2awvim61k2ji6c-glibc-2.42-67/lib/libc.so.6
#5  0x00007ffff6d31444 in __chk_fail ()
   from /nix/store/ias8xacs1h3jy7xgwi2awvim61k2ji6c-glibc-2.42-67/lib/libc.so.6
#6  0x00007ffff6d32f1d in __snprintf_chk ()
   from /nix/store/ias8xacs1h3jy7xgwi2awvim61k2ji6c-glibc-2.42-67/lib/libc.so.6
#7  0x0000555555624593 in set_full_path.part.0.constprop ()
#8  0x00005555556268ed in create_directory_tree ()
#9  0x00005555555ff7ac in library_init ()
#10 0x000055555562e50b in kew_init ()
#11 0x000055555562e56f in default_state_init ()
#12 0x0000555555574eb7 in main ()

Changing `KEW_PATH_MAX` to `needed` in `set_full_path()` solved problem.

Changed `installFlags` to `makeFlags` to ensure correct build and install.