### PR TITLE
Fix crash in mpris_init when D-Bus connection fails

### DIFF
--- a/src/sys/mpris.c
+++ b/src/sys/mpris.c
@@ -1110,10 +1110,11 @@ void mpris_init(void)
                 g_printerr("%s\n", error->message);
                 k_log("%s", error->message);
                 k_log("Failed to connect to D-Bus. Either 1) start D-BUS, 2) recompile with USE_DBUS=0 or 3) use dbus-launch kew 4) run: doas setcap -r /usr/local/bin/kew");
+                set_error_message(error->message);
                 g_error_free(error);
                 g_dbus_node_info_unref(introspection_data);
-                set_error_message(error->message);
                 quit();
+                return;
         }
 
         set_gd_bus_connection(conn);
@@ -1123,6 +1124,7 @@ void mpris_init(void)
                 k_log("Failed to connect to D-Bus. Either 1) start D-BUS, 2) recompile with USE_DBUS=0 or 3) use dbus-launch kew");
                 set_error_message("Failed to connect to D-Bus. Either 1) start D-BUS, 2) recompile with USE_DBUS=0 or 3) use dbus-launch kew 4) run: doas setcap -r /usr/local/bin/kew");
                 quit();
+                return;
         }
 
         const char *app_name = "org.mpris.MediaPlayer2.kew";


### PR DESCRIPTION
Since 4.2.7, kew crashes when there is no D-Bus session bus (e.g. containers, CI). Caught by Homebrew CI (Homebrew/homebrew-core#293942).

Two bugs in the `g_bus_get_sync()` failure path of `mpris_init()`:

1. `set_error_message(error->message)` is called after `g_error_free(error)`; use-after-free, crashes with SIGSEGV.
2. `quit()` only sets a flag, and without a `return` the function falls through: `introspection_data` is unreffed twice and a NULL connection is passed to `g_bus_own_name_on_connection()`, aborting with heap corruption.

Fix: set the error message before freeing, and return early after `quit()` in both branches.
