### PR TITLE
docs: fix minor typos in LAYOUTS-HOWTO.md

### DIFF
--- a/layouts/LAYOUTS-HOWTO.md
+++ b/layouts/LAYOUTS-HOWTO.md
@@ -56,7 +56,7 @@ visualizer, progress, song, playlist, library, search, footer, layout
 
 ## Components
 
-NOTE: error_row is a required component. Otherwise you wont be able to visibly name a playlist.
+NOTE: error_row is a required component. Otherwise you won't be able to visibly name a playlist.
 
 Every region that does anything is a component. The allowed components are:
 
@@ -82,7 +82,7 @@ help, version
 
 ## Limitations
 
-We still ideally would like to allow people to have things like the playlist and library on the same view, decide which views to include and name them in the footer. That sort of stuff is currently not possible. The playlist component has to be in the playlist view and so on or it wont work.
+We still ideally would like to allow people to have things like the playlist and library on the same view, decide which views to include and name them in the footer. That sort of stuff is currently not possible. The playlist component has to be in the playlist view and so on or it won't work.
 
 
 ## Example


### PR DESCRIPTION
Fixes two small typos found while reading the docs:

- `wont` -> `won't` (x2)

No functional changes.