### PR TITLE
Fix typos in comments

### DIFF
--- a/src/loader/lyrics.cpp
+++ b/src/loader/lyrics.cpp
@@ -240,7 +240,7 @@ static int loadUntimedLyrics(FILE *file, Lyrics *lyrics)
         return 1;
 }
 
-//helper function findLRC that find wether current folder have a .lrc file match the word
+//helper function findLRC that find whether current folder have a .lrc file match the word
 static char *findLRC(const char *folder, const char *word)
 {
         static char result[KEW_PATH_MAX];

--- a/src/update/effects.h
+++ b/src/update/effects.h
@@ -85,6 +85,6 @@ void run_command(UpdateResult result);
 /**
  * @brief Checks if a resize is needed and resizes if it is.
  *
- * @return True if a resize occured.
+ * @return True if a resize occurred.
  */
 bool resize_if_needed(void);


### PR DESCRIPTION
Two typos in code comments:

- `src/update/effects.h:88` - `occured` -> `occurred`
- `src/loader/lyrics.cpp:243` - `wether` -> `whether`

Comments only, no functional change.
