### PR TITLE
fix: NULL pointer dereference in set_prefs when playing file outside library

### DIFF
--- a/src/ui/settings.c
+++ b/src/ui/settings.c
@@ -2070,8 +2070,10 @@ void set_prefs(AppSettings *settings, UISettings *ui)
         // Save current song id and seconds for auto-resume
         if (current) {
                 FileSystemEntry *entry = find_corresponding_entry(model->library, current->song.file_path);
-                fprintf(file, "currentSongId=%d\n", entry->id);
-                fprintf(file, "currentSongSeconds=%f\n", model->elapsed_seconds);
+                if (entry != NULL) {
+                        fprintf(file, "currentSongId=%d\n", entry->id);
+                        fprintf(file, "currentSongSeconds=%f\n", model->elapsed_seconds);
+                }
         }
 
         fclose(file);


### PR DESCRIPTION
## Problem

When playing a file that is not part of the music library (e.g. `kew play /tmp/song.mp3`), kew crashes with SIGSEGV on quit (pressing `q`).

**Coredump stack (main thread):**

```
#0  kew + 0xbb587   mov (%rax),%ecx   <- deref of find_corresponding_entry() result
#1  kew + 0xcb446   (set_prefs caller in kew_shutdown)
#2  kew + 0xcb7e4   (create_loop)
#3  kew + 0xcb95f
#4  kew + 0x143fc   (main)
```

## Root cause

`src/ui/settings.c` in `set_prefs()`, auto-resume state saving:

```c
if (current) {
        FileSystemEntry *entry = find_corresponding_entry(model->library, current->song.file_path);
        fprintf(file, "currentSongId=%d\n", entry->id);   // entry can be NULL
        fprintf(file, "currentSongSeconds=%f\n", model->elapsed_seconds);
}
```

`find_corresponding_entry()` only searches the music library directory tree. When the current song was started via `kew play <path>` (or a playlist of files outside the library, e.g. from a file manager like yazi), it returns NULL and `entry->id` dereferences it.

This triggers on every quit while playing a library-external file, so it is easy to hit with CLI playback workflows.

## Fix

Check the return value before writing the auto-resume fields:

```c
if (current) {
        FileSystemEntry *entry = find_corresponding_entry(model->library, current->song.file_path);
        if (entry != NULL) {
                fprintf(file, "currentSongId=%d\n", entry->id);
                fprintf(file, "currentSongSeconds=%f\n", model->elapsed_seconds);
        }
}
```

## Verification

- Reproduced: `kew play Song-1.mp3` then `q` -> SIGSEGV (exit code -11)
- After fix: clean exit (code 0)

## Note

The auto-resume feature is not usable for library-external files anyway (no library entry exists to resume), so skipping the write is harmless.