### PR TITLE
fix: show only the year when the date tag contains a full date

### DIFF
--- a/src/ui/components.c
+++ b/src/ui/components.c
@@ -692,7 +692,10 @@ int get_year(const char *date_string)
 {
         int year;
 
-        if (sscanf(date_string, "%d", &year) != 1) {
+        // Read at most four digits so that full dates such as
+        // "20060203" or "2006-02-03" yield the year (2006), not the
+        // whole number.
+        if (sscanf(date_string, "%4d", &year) != 1) {
                 return -1;
         }
         return year;


### PR DESCRIPTION
## Problem

Fixes #577.

When a track's date tag holds a full date such as `20060203`, the track view renders the entire number (`20060203`) instead of just the year (`2006`).

## Root cause

`get_year()` (`src/ui/components.c`) parses `metadata->date` with `sscanf(date_string, "%d", &year)`. `%d` consumes the whole digit run, so `"20060203"` is parsed as the integer 20060203 and returned as-is.

## Change

Limit the conversion to the first four digits with `%4d`:

- `"20060203"` → 2006
- `"2006-02-03"` → 2006 (unchanged behavior)
- `"2006"` → 2006 (unchanged behavior)
- non-numeric input still returns -1, so the caller falls back to printing the raw string as before

This matches the design intent from the issue discussion: display the year, not the full date.

## Testing

- Extracted `get_year()` before and after the change into a standalone harness with 10 cases (full YYYYMMDD dates, ISO-style dates, plain years, garbage input). The pre-change version fails on the `20060203`/`19991231` cases; the fixed version passes all of them.
- Full local build passes on macOS (`make`, `-Wall -Wextra`).