### PR TITLE
fix: uninitialized album line causing random garbled text in track view

### DIFF
--- a/src/ui/components.c
+++ b/src/ui/components.c
@@ -1967,7 +1967,7 @@ ComponentMsg component_metadata(const Model *model, k_Rect region, DrawBuffer *b
                 // Album
                 if (region.height >= 3) {
                         CellStyle style = cell_style_from_theme(ui->theme.trackview_album);
-                        char line[METADATA_MAX_LENGTH + 2];
+                        char line[METADATA_MAX_LENGTH + 2] = {0};
                         char *album = NULL;
                         if (!is_root_dir) {
                                 album = basename(dir);


### PR DESCRIPTION
## Problem

When playing a song, the album line in the track view occasionally shows random garbled text (e.g. `0�HP�`), and the content differs on each launch. The title and other lines are fine.

## Root cause

The album branch in `component_metadata()` reads uninitialized memory:

```c
char line[METADATA_MAX_LENGTH + 2];   // uninitialized stack variable
char *album = NULL;
if (!is_root_dir) {
        album = basename(dir);
}
if (strnlen(metadata->album, METADATA_MAX_LENGTH) > 0) {
        snprintf(line, sizeof(line), "%s", metadata->album);
} else if (album) {
        snprintf(line, sizeof(line), "%s", album);
}
if (line[0] != '\0')                  // reads uninitialized memory
        draw_buffer_set_string_truncated(buf, region.row + 2, region.col,
                                         line, max_width, style);
```

Neither `snprintf` runs when both of the following are true:

1. `is_root_dir` is true (the directory of the playing file == `settings.path`, i.e. the `path` configured in kewrc)
2. The file has no album tag (`metadata->album` is empty)

In that case `line` holds garbage from the stack, and `line[0]` is very likely non-zero (255/256 chance), so the uninitialized memory is drawn as text. The garbage depends on the stack state, which is why it differs on every launch.

## Reproduce

- Set `path=/tmp/music` in kewrc and play an mp3 without an album tag in that directory
- Building with `-ftrivial-auto-var-init=pattern` reproduces it 100% (uninitialized variables are filled with 0xFE, and the album line shows a screen full of garbage)

## Fix

Initialize the `line` array to `{0}`:

```c
char line[METADATA_MAX_LENGTH + 2] = {0};
```

When `line[0] == '\0'`, nothing is drawn and the line is cleanly skipped. Normal cases are unaffected: the album name or directory fallback is still shown as before.

## Verification

| Scenario | Before | After |
|---|---|---|
| Root dir + no album tag | Random garbage (guaranteed with pattern build) | No garbage, line is blank |
| Root dir + album tag | Album name shown correctly | Album name shown correctly |
| Non-root dir (directory fallback) | Directory name shown correctly | Directory name shown correctly |

This bug exists in both v4.2.7 and master.
