### PR TITLE
queue: fix playlist corruption when enqueueing from the library root

### DIFF
--- a/src/data/playlist.c
+++ b/src/data/playlist.c
@@ -258,6 +258,13 @@ void shuffle_playlist(PlayList *playlist)
                 playlist->count = i;
         }
 
+        if (playlist->count < 1) {
+                playlist->head = NULL;
+                playlist->tail = NULL;
+                free(nodes);
+                return;
+        }
+
         // Shuffle the array using Fisher-Yates algorithm
         for (int j = playlist->count - 1; j >= 1; --j) {
                 int k = rand() % (j + 1);

--- a/src/ui/queue_ui.c
+++ b/src/ui/queue_ui.c
@@ -194,7 +194,7 @@ Node *enqueue_songs(FileSystemEntry *entry, FileSystemEntry **chosen_dir, bool d
         }
 
         bool shuffle = false;
-        if (first_enqueued_entry) {
+        if (first_enqueued_entry && entry->is_directory) {
                 int depth = get_relative_depth(model->library->full_path, entry->full_path);
 
                 if (depth == 0 || depth == 1)
@@ -211,8 +211,7 @@ Node *enqueue_songs(FileSystemEntry *entry, FileSystemEntry **chosen_dir, bool d
                 if (first_enqueued_node)
                 {
                         shuffle_playlist_starting_from_song(model->playlist, first_enqueued_node);
-                        move_down_list(model->playlist, first_enqueued_node, true);
-                        move_down_list(model->unshuffled_playlist, first_enqueued_node, true);
+                        move_down_list(model->playlist, first_enqueued_node, false);
                 }
                 else
                         shuffle_playlist(model->playlist);


### PR DESCRIPTION
Follow-up to [Codeberg issue 279](https://codeberg.org/ravachol/kew/issues/279),
"Crash after enqueuing 4 songs". The guard in c8e1541 stopped the
segfault, so the issue was closed, but the list corruption behind it is still
there. It is just silent now: from the fourth song on, the song is added and
`count` is incremented, but it never appears in the queue.

### The corruption

`enqueue_songs()` looks up `first_enqueued_node` in `model->playlist`, then
passes that same node to `move_down_list()` for `model->unshuffled_playlist`:

```c
first_enqueued_node = find_path_in_playlist(first_enqueued_entry->full_path, model->playlist);
...
move_down_list(model->playlist, first_enqueued_node, true);
move_down_list(model->unshuffled_playlist, first_enqueued_node, true);
```

`move_down_list()` relinks through `node->prev`/`node->next` and writes
`list->head`/`list->tail`, so the second call rewires nodes belonging to
`playlist` while assigning them to `unshuffled_playlist`.

The first two enqueues return early (`node->next == NULL`). The third one leaves
`unshuffled_playlist->tail` pointing at a node owned by `playlist`. From the
fourth song on, `add_to_list()` appends to that node instead: the song is added
and `count` is incremented, but it is never reachable from
`unshuffled_playlist->head`, so the queue keeps showing three.

A 4.3.0 core dump of the segfault shows that end state: `unshuffled_playlist`
with `count == 4`, three nodes reachable from `head` (ids 180, 183, 182), and
`tail` pointing at a live node with id 181 that is not in that chain.

That stale `tail` also explains the double frees. `dequeue_song()` calls
`find_last_path_in_playlist()`, which walks backwards from `tail`, so the search
runs through `playlist`'s chain and can return a node owned by `playlist`. The
`find_selected_entry_by_id(playlist, id)` right after searches the same list, so
the two can resolve to the same `Node`, which is then freed twice — the
`node1 == node2` case the `abort()` in 0adf9db was added to catch.

The enclosing `if` is `(is_shuffle_enabled() && !is_root && num_enqueued) ||
shuffle`, so this is reachable two ways: with shuffle enabled for any library
layout, and with shuffle disabled when `get_relative_depth()` returns 0 or 1,
i.e. for music files sitting directly in the library root. With shuffle on, a
library organised in folders is affected too: on 80308f78, enqueueing a
six-track album leaves one track in the queue; with this branch, six.

`move_song_up()`/`move_song_down()` already show the intended pattern: each list
gets its own node, looked up by id, and `change_library_status` is passed only
for the unshuffled list. Dropping the call rather than fixing the node is
deliberate: for a single song the corresponding node is already the tail of
`unshuffled_playlist`, so the call would return immediately, and for a directory
it would swap the first two tracks of what was just enqueued.

### The forced shuffle

The same block set `shuffle` for any depth-0/1 entry. `is_root` is handled
separately below, so this concerns depth-1 entries: albums or artists in a
foldered library, but individual songs in a flat one, where enqueueing a single
song reshuffled the whole queue even with shuffle disabled. Restricting it to
directories keeps the original intent.

### The out-of-bounds read

Unrelated, but in the same area. After the guard in c8e1541 clamps `count` to 0,
`shuffle_playlist()` still runs:

```c
playlist->head = nodes[0];                    // never written by the walk
playlist->tail = nodes[playlist->count - 1];  // nodes[-1]
```

AddressSanitizer on that input (`head == NULL`, `count == 4`), with the function
copied verbatim into a standalone harness:

```
ERROR: AddressSanitizer: heap-buffer-overflow, READ of size 8
0x... is located 8 bytes before 32-byte region
    #0 shuffle_playlist  ->  playlist->tail = nodes[playlist->count - 1];
```

### Before / after

Same key sequence in every clip: shuffle disabled, ten loose files in the library
root, Enter on each, then F2 to show the queue.

Current `develop` (80308f78) — the queue stops at three:

https://github.com/user-attachments/assets/e5091537-ac0b-44b0-9598-ee9604f78398


With this branch — all ten, in order:

https://github.com/user-attachments/assets/d68a7839-89b5-43d2-8b53-2d06b91ac858

For reference, the released 4.3.0 build segfaults on the same sequence, which is
the crash from issue 279:

https://github.com/user-attachments/assets/ad074625-4d18-431c-a076-f4e8cca5670a
