### PR TITLE
fix: bump version to match with latest release

### DIFF
--- a/src/kew.c
+++ b/src/kew.c
@@ -35,7 +35,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
 #endif
 
 #ifndef KEW_VERSION
-#define KEW_VERSION "4.3.0"
+#define KEW_VERSION "4.3.1"
 #endif
 
 #include "common/appstate.h"

--- a/website/site_src/download.md
+++ b/website/site_src/download.md
@@ -19,11 +19,10 @@ Available through the package manager or [manual installation guide](https://cod
 
 ## WINDOWS
 
-Run the [Windows installer](https://github.com/ravachol/kew/releases/download/v4.3.0/kew-4.3.0-windows-x64.exe), compiled and created entirely on Github.com.
+Run the [Windows installer](https://github.com/ravachol/kew/releases/download/v4.3.1/kew-4.3.1-windows-x64.exe), compiled and created entirely on Github.com.
 
 (sha256:aa567beb61f64c46fc28b333ef838e474351157270b31effac5a63a7215c0df1)
 
 ## ANDROID
 
 kew is available on Android as a package for the app [Termux](https://termux.dev), which is a terminal emulator for Android.
-


### PR DESCRIPTION
seeing some version output issue and bump the version to 4.3.1

- https://github.com/Homebrew/homebrew-core/pull/302445